### PR TITLE
fix dimensions in ellipsoid geometry

### DIFF
--- a/src/GEOM.jl
+++ b/src/GEOM.jl
@@ -145,7 +145,6 @@ function geometry(shape::Ellipsoid, ::Naked)
     a = ((3 / 4)* Unitful.ustrip(volume) / (π * shape.b * shape.c)) ^ (1 / 3)
     b = a * shape.b
     c = a * shape.c
-    p = 1.6075
     length1 = a * 2m
     length2 = b * 2m
     length3 = c * 2m

--- a/src/GEOM.jl
+++ b/src/GEOM.jl
@@ -142,13 +142,13 @@ end
 function geometry(shape::Ellipsoid, ::Naked)
     volume = shape.mass / shape.density
     length = volume^(1 / 3)
-    a = ((3 / 4)* volume / (π * shape.b * shape.c)) ^ (1 / 3)
+    a = ((3 / 4)* Unitful.ustrip(volume) / (π * shape.b * shape.c)) ^ (1 / 3)
     b = a * shape.b
     c = a * shape.c
     p = 1.6075
-    length1 = a * 2
-    length2 = b * 2
-    length3 = c * 2
+    length1 = a * 2m
+    length2 = b * 2m
+    length3 = c * 2m
     area = area_of_ellipsoid(a, b, c)
     return Geometry(volume, length, (length1, length2, length3), area)
 end

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -283,26 +283,22 @@ function conduction(A, L, T_org, T_sub, k_sub)
     A * (k_sub / L) * (T_org - T_sub)
 end
 
-function solar(α_org, A_sil, A_up, A_down, α_sub, Q_direct, Q_diffuse, Z)
-    Q_norm = Q_direct / cos(Z)
-    Q_direct = α_org * A_sil * Q_norm
-    Q_diffuse = α_org * A_up * Q_diffuse + α_org * A_down * (Q_direct + Q_diffuse) * (1 - α_sub)
-    Q_direct + Q_norm
+function solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
+    Q_direct = α_org_dorsal * A_sil * Q_dir
+    Q_sol_sky = α_org_dorsal * F_sky * A_up * Q_dif
+    Q_sol_sub = α_org_ventral * F_sub * A_down * (1 - α_sub) * (Q_dir + Q_dif)
+    (Q_direct + Q_sol_sub + Q_sol_sky)
 end
 
 
 function radin(A_tot = 0.01325006m^2,
-    A_cond = 0.001325006m^2,
-    A_cont = 0m^2,
     F_sky = 0.4,
     F_sub = 0.4,
-    F_obj = 0,
     ϵ_org = 0.95,
     ϵ_sub = 0.95,
     ϵ_sky = 0.8,
     T_sky = (10+273.15)K,
-    T_sub = (30+273.15)K,
-    T_obj = T_sub)
+    T_sub = (30+273.15)K)
 
 σ_IR =5.670374419e-8W/m^2/K^4
 
@@ -310,28 +306,22 @@ F_sky = F_sky - F_obj
 if F_sky < 0
     F_sky = 0
 end
-Q_ir_sky = ϵ_org * F_sky * (A_tot-A_cont / 2) * ϵ_sky * σ_IR * T_sky ^ 4
-Q_ir_sub = ϵ_org * F_sub * (A_tot-A_cond-A_cont / 2) * ϵ_sub * σ_IR * T_sub ^ 4
-Q_ir_obj = ϵ_org * F_obj * (A_tot-A_cont / 2) * ϵ_sub * σ_IR * T_obj ^ 4
-Q_ir_in = Q_ir_sky + Q_ir_sub + Q_ir_obj
-(Q_ir_in)
+Q_ir_sky = ϵ_org * F_sky * A_tot * ϵ_sky * σ_IR * T_sky ^ 4
+Q_ir_sub = ϵ_org * F_sub * A_tot * ϵ_sub * σ_IR * T_sub ^ 4
+(Q_ir_sky + Q_ir_sub)
 end
 
 function radout(
     T_skin = (25.1+273.15)K,
     A_tot = 0.01325006m^2,
-    A_cond = 0.001325006m^2,
-    A_cont = 0m^2,
     F_sky = 0.4,
     F_sub = 0.4,
     ϵ_org = 0.95)
 # C     COMPUTES LONGWAVE RADIATION LOST
 σ_IR =5.670374419e-8W/m^2/K^4
-X = T_skin
-Q_ir_to_sky = (A_tot - A_cont / 2) * F_sky * ϵ_org * σ_IR  * X ^ 4
-Q_ir_to_sub = (A_tot - A_cond - A_cont / 2) * F_sub * ϵ_org * σ_IR  * X ^ 4
-Q_ir_out = Q_ir_to_sky + Q_ir_to_sub
-(Q_ir_out)
+Q_ir_to_sky = A_tot * F_sky * ϵ_org * σ_IR  * T_skin ^ 4
+Q_ir_to_sub = A_tot * F_sub * ϵ_org * σ_IR  * T_skin ^ 4
+(Q_ir_to_sky + Q_ir_to_sub)
 end
 
 function evap(

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -9,9 +9,12 @@ include("./Ectotherm.jl/src/heat_balance.jl")
 T_air = (20+273.15)K
 T_surf = (25.1+273.15)K
 T_core = (20.2+273.15)K
+Z = 0°
 F_sky = 0.4
 F_sub = 0.4
 F_obj = 0
+α_org_dorsal = 0.8
+α_org_ventral = 0.8
 ϵ_org = 0.95
 ϵ_sub = 0.95
 ϵ_sky = 0.8
@@ -24,6 +27,9 @@ AEFF = 1.192505e-05m^2
 A_tot = 0.01325006m^2
 hd = 0.02522706m/s
 PEYES = 0.03 / 100
+α_sub = 0.85
+Q_dir = 800W/m^2
+Q_dif = 100W/m^2
 rh = 50
 elev = 0m
 vel = 1m/s
@@ -32,15 +38,19 @@ p_cond = 0.1
 p_cont = 0
 A_v = A_tot * p_cond
 A_t = A_tot * p_cont
+A_sil = A_tot / 2
+A_up = A_tot / 2
+A_down = A_tot / 2
 
-RADIN = radin(A_tot, A_v, A_t, F_sky, F_sub, F_obj, ϵ_org, ϵ_sub, ϵ_sky, T_sky, T_sub)
-RADOUT = radout(T_surf, A_tot, A_v, A_t, F_sky, F_sub, ϵ_org)
+Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org, ϵ_sub, ϵ_sky, T_sky, T_sub)
+Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org)
 
 GEVAP = 1.177235e-09kg/s
 T_air = (20+273.15)K
 T_surf = (25.1+273.15)K
 T_core = (25+273.15)K
 EVAP = evap(T_core, T_surf, GEVAP, ψ_org, SKINW, AEFF, A_tot, hd, PEYES, T_air, rh, vel, P_atmos)
+Q_evap = EVAP.QSEVAP
 
 density = 1000kg/m^3
 trunkmass = 0.04kg
@@ -48,7 +58,12 @@ trunkshapeb = 3
 trunkshape = Cylinder(trunkmass, density, trunkshapeb) 
 trunk = Body(trunkshape, Naked())
 T_surf = (25+273.15)K
-A_v = 0.01192505
+A_v = 0.01192505m^2
 CONV = convection(trunk, A_v, T_air, T_surf, vel, P_atmos, elev, fluid)
+Q_conv = CONV.Q_conv
 
+Q_norm = Q_dir / cos(Z)
+Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, α_sub, F_sub, F_sky, Q_dir, Q_dif)
+
+Q_solar + Q_conv + Q_evap + Q_IR_in + Q_IR_out
 # heat_balance(trunk, params, env)


### PR DESCRIPTION
Fixing dimensional issue in ellipsoid area calculation where units had to be stripped from volume in calculating 'a' and then units of m needed to be added to all three lengths. Also removed unnecessary variable 'p', which was used in the ectotherm ellipsoid area calculation but not the endotherm model calculation. And worked on radiation functions so now whole heat budget can be computed.