### PR TITLE
adding functions for T_skin and T_lung

### DIFF
--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -199,29 +199,29 @@ function get_Nusselt_forced(shape::Ellipsoid, Re)
 end
 
 function water_prop(T_water)
-  # β = coefficient of expansion (1/K)
-  # cp_fluid = specific heat (J/kg-K)
-  # ρ_water = water density (kg/m3)
-  # k_fluid = thermal conductivity (W/m-K)
-  # μ = dynamic viscosity (kg/m-s)
-  β = 0.21E-031/K
-  T_water = Unitful.ustrip(T_water)-273.15
-  cp_fluid = 4220.02 - 4.5531 * T_water + 0.182958  * T_water ^ 2 - 0.00310614 *  T_water ^ 3 + 1.89399E-5 * T_water ^ 4
-  cp_fluid = (cp_fluid)J/kg/K
-  if T_water < 30
-    ρ_water = 1000.
-  else
-    if T_water <= 60
-        ρ_water = 1017 - 0.6 * T_water
+    # β = coefficient of expansion (1/K)
+    # cp_fluid = specific heat (J/kg-K)
+    # ρ_water = water density (kg/m3)
+    # k_fluid = thermal conductivity (W/m-K)
+    # μ = dynamic viscosity (kg/m-s)
+    β = 0.21E-031 / K
+    T_water = Unitful.ustrip(T_water) - 273.15
+    cp_fluid = 4220.02 - 4.5531 * T_water + 0.182958 * T_water^2 - 0.00310614 * T_water^3 + 1.89399E-5 * T_water^4
+    cp_fluid = (cp_fluid)J / kg / K
+    if T_water < 30
+        ρ_water = 1000.0
     else
-        T_water = 60
-        ρ_water = 1017 - 0.6 * T_water
+        if T_water <= 60
+            ρ_water = 1017 - 0.6 * T_water
+        else
+            T_water = 60
+            ρ_water = 1017 - 0.6 * T_water
+        end
     end
-end
-  k_fluid = (0.551666+0.00282144 * T_water - 2.02383E-5 * T_water ^ 2)W/m/K
-  μ = (0.0017515-4.31502E-5 * T_water + 3.71431E-7 * T_water ^ 2)kg/m/s
-  ρ_water = (ρ_water)kg/m^3
-  (β = β, cp_fluid = cp_fluid, ρ_water = ρ_water, k_fluid = k_fluid, μ = μ)
+    k_fluid = (0.551666 + 0.00282144 * T_water - 2.02383E-5 * T_water^2)W / m / K
+    μ = (0.0017515 - 4.31502E-5 * T_water + 3.71431E-7 * T_water^2)kg / m / s
+    ρ_water = (ρ_water)kg / m^3
+    (β=β, cp_fluid=cp_fluid, ρ_water=ρ_water, k_fluid=k_fluid, μ=μ)
 end
 
 function convection(Body, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
@@ -307,7 +307,8 @@ function solar(α_org_dorsal=0.85,
     Q_direct = α_org_dorsal * A_sil * Q_dir
     Q_sol_sky = α_org_dorsal * F_sky * A_tot * Q_dif
     Q_sol_sub = α_org_ventral * F_sub * (A_tot - A_cond) * (1 - α_sub) * Q_sol
-    (Q_direct + Q_sol_sub + Q_sol_sky)
+    Q_solar = (Q_direct + Q_sol_sub + Q_sol_sky)
+    (Q_solar = Q_solar, Q_direct = Q_direct, Q_sol_sky = Q_sol_sky, Q_sol_sub = Q_sol_sub)
 end
 
 function radin(A_tot=0.01325006m^2,
@@ -324,76 +325,78 @@ function radin(A_tot=0.01325006m^2,
     σ = Unitful.uconvert(u"W/m^2/K^4", Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
     Q_ir_sky = ϵ_org_dorsal * F_sky * A_tot * ϵ_sky * σ * T_sky^4
     Q_ir_sub = ϵ_org_ventral * F_sub * (A_tot - A_cond) * ϵ_sub * σ * T_sub^4
-    (Q_ir_sky + Q_ir_sub)
+    Q_ir_in = Q_ir_sky + Q_ir_sub
+    (Q_ir_in=Q_ir_in, Q_ir_sky=Q_ir_sky, Q_ir_sub=Q_ir_sub)
 end
 
 function radout(
-    T_surf = (25.1+273.15)K,
-    A_tot = 0.01325006m^2,
-    A_cond = 0.001325006m^2,
-    F_sky = 0.4,
-    F_sub = 0.4,
-    ϵ_org_dorsal = 0.95,
-    ϵ_org_ventral = 0.95)
-# computes longwave radiation lost
-σ = Unitful.uconvert(u"W/m^2/K^4",Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
-Q_ir_to_sky = A_tot * F_sky * ϵ_org_dorsal * σ  * T_surf ^ 4
-Q_ir_to_sub = (A_tot - A_cond) * F_sub * ϵ_org_ventral * σ  * T_surf ^ 4
-(Q_ir_to_sky + Q_ir_to_sub)
+    T_surf=(25.1 + 273.15)K,
+    A_tot=0.01325006m^2,
+    A_cond=0.001325006m^2,
+    F_sky=0.4,
+    F_sub=0.4,
+    ϵ_org_dorsal=0.95,
+    ϵ_org_ventral=0.95)
+    # computes longwave radiation lost
+    σ = Unitful.uconvert(u"W/m^2/K^4", Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
+    Q_ir_to_sky = A_tot * F_sky * ϵ_org_dorsal * σ * T_surf^4
+    Q_ir_to_sub = (A_tot - A_cond) * F_sub * ϵ_org_ventral * σ * T_surf^4
+    Q_ir_out = Q_ir_to_sky + Q_ir_to_sub
+    (Q_ir_out=Q_ir_out, Q_ir_to_sky=Q_ir_to_sky, Q_ir_to_sub=Q_ir_to_sub)
 end
 
 function evaporation(
-    T_core = (25+273.15)K,
-    T_surf = (25.1+273.15)K,
-    m_resp = 1.177235e-09kg/s,
-    ψ_org = -7.07 * 100J/kg,
-    p_wet = 0.1 / 100,
-    A_tot = 0.01325006m^2,
-    Hd = 0.02522706m/s,
-    p_eyes = 0.03 / 100,
-    T_air = (20+273.15)K,
-    rh = 50,
-    elev = 0m,
-    P_atmos = 101325Pa)
-    
-  # this subroutine computes surface evaporation based on the mass transfer
-  # coefficient, fraction of surface of the skin acting as a free water surface
-  # and exposed to the air, and the vapor density gradient between the
-  # surface and the air, each at their own temperature.
+    T_core=(25 + 273.15)K,
+    T_surf=(25.1 + 273.15)K,
+    m_resp=1.177235e-09kg / s,
+    ψ_org=-7.07 * 100J / kg,
+    p_wet=0.1 / 100,
+    A_tot=0.01325006m^2,
+    Hd=0.02522706m / s,
+    p_eyes=0.03 / 100,
+    T_air=(20 + 273.15)K,
+    rh=50,
+    elev=0m,
+    P_atmos=101325Pa)
 
-  # get vapour density at surface based on water potential of body
-  m_w = 0.018kg/mol #! molar mass of water, kg/mol
-  rh_surf = exp(ψ_org / (Unitful.R / m_w * T_surf)) * 100 #
-  wet_air_out = wet_air(T_surf, 0K, rh_surf, nothing, P_atmos)
-  ρ_vap_surf = wet_air_out.ρ_vap
+    # this subroutine computes surface evaporation based on the mass transfer
+    # coefficient, fraction of surface of the skin acting as a free water surface
+    # and exposed to the air, and the vapor density gradient between the
+    # surface and the air, each at their own temperature.
 
-  # get air vapour density
-  wet_air_out = wet_air(T_air, 0K, rh, nothing, P_atmos)
-  ρ_vap_air = wet_air_out.ρ_vap
+    # get vapour density at surface based on water potential of body
+    m_w = 0.018kg / mol #! molar mass of water, kg/mol
+    rh_surf = exp(ψ_org / (Unitful.R / m_w * T_surf)) * 100 #
+    wet_air_out = wet_air(T_surf, 0K, rh_surf, nothing, P_atmos)
+    ρ_vap_surf = wet_air_out.ρ_vap
 
-  # water lost from eyes if present
-  m_eyes = Hd * p_eyes * A_tot * (ρ_vap_surf - ρ_vap_air)
-  if m_eyes > 0kg/s
-    m_cut = (A_tot * p_wet  - A_tot * p_wet * p_eyes) * Hd * (ρ_vap_surf - ρ_vap_air)
-  else
-    m_cut = A_tot * p_wet * Hd * (ρ_vap_surf - ρ_vap_air)
-  end
-  
-  # total water lost
-  m_evap = m_eyes + m_resp + m_cut
+    # get air vapour density
+    wet_air_out = wet_air(T_air, 0K, rh, nothing, P_atmos)
+    ρ_vap_air = wet_air_out.ρ_vap
 
-  # get latent heat of vapourisation and compute heat exchange due to evaporation
-  dry_air_out = dry_air(T_air, P_atmos, elev)
-  L_v = dry_air_out.L_v
-  Q_evap = Unitful.uconvert(u"W",(m_eyes + m_cut) * L_v)
-  
-  #onvert from kg/s to g/s
-  m_eyes = uconvert(u"g/s",m_eyes)
-  m_resp = uconvert(u"g/s",m_resp)
-  m_cut = uconvert(u"g/s",m_cut)
-  m_evap = uconvert(u"g/s",m_evap)
+    # water lost from eyes if present
+    m_eyes = Hd * p_eyes * A_tot * (ρ_vap_surf - ρ_vap_air)
+    if m_eyes > 0kg / s
+        m_cut = (A_tot * p_wet - A_tot * p_wet * p_eyes) * Hd * (ρ_vap_surf - ρ_vap_air)
+    else
+        m_cut = A_tot * p_wet * Hd * (ρ_vap_surf - ρ_vap_air)
+    end
 
-  (Q_evap = Q_evap, m_evap = m_evap, m_resp = m_resp, m_cut = m_cut, m_eyes = m_eyes)
+    # total water lost
+    m_evap = m_eyes + m_resp + m_cut
+
+    # get latent heat of vapourisation and compute heat exchange due to evaporation
+    dry_air_out = dry_air(T_air, P_atmos, elev)
+    L_v = dry_air_out.L_v
+    Q_evap = Unitful.uconvert(u"W", (m_eyes + m_cut) * L_v)
+
+    #onvert from kg/s to g/s
+    m_eyes = uconvert(u"g/s", m_eyes)
+    m_resp = uconvert(u"g/s", m_resp)
+    m_cut = uconvert(u"g/s", m_cut)
+    m_evap = uconvert(u"g/s", m_evap)
+
+    (Q_evap=Q_evap, m_evap=m_evap, m_resp=m_resp, m_cut=m_cut, m_eyes=m_eyes)
 end
 
 """
@@ -421,77 +424,86 @@ if atmospheric pressure is unknown, elevation will be used to estimate it.
     ...    
 """
 function respiration(
-    T_x = 296.15K,
-    Q_metab = 0.01241022W,
-    fO2_extract = 0.20,
-    pant = 1,
-    rq = 0.8,
-    T_air = 293.15K,
-    rh = 50,
-    elev = nothing,
-    P_atmos = 101325Pa,
-    fO2 = 0.2095,
-    fCO2 = 0.0003,
-    fN2 = 0.7902)
-  
-  # adjust O2 to ensure sum to 1
-  if fO2 + fCO2 + fN2  !=  1
-    fO2 = 1 - (fN2 + fCO2)
-  end
-  P_O2 = P_atmos * fO2
-  Joule_m3_O2 = 20.1e6J/m^3 # joules of energy dissipated per m3 O2 consumed at STP (enthalpy of combustion)
-  V_O2_STP = uconvert(u"m^3/s", Q_metab / Joule_m3_O2)
-  
-  # converting stp -> vol. of O2 at animal lung temperature, atm. press.
-  T_lung = T_x
-  V_O2 = (V_O2_STP * P_O2 / 273.15K) * (T_lung / P_O2)
-  #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
-  J_O2 = uconvert(u"mol/s", P_atmos * V_O2 / (R * T_x)) # mol O2 consumed
-  # moles/s of O2, N2, dry air at entrance [air flow = f(O2 consumption)]
-  J_O2_in = J_O2 / fO2_extract # actual oxygen flow in (moles/s), accounting for efficiency of extraction
-  J_N2_in = J_O2_in * (fN2 / fO2) #  actual nitrogen flow in (moles/s), accounting for efficiency of extraction
-  V_air = V_O2 / fO2 # air flow
-  V_CO2 = fCO2 * V_air #O2 flow
-  J_CO2_in = P_atmos * V_CO2 / (R * T_lung)
-  J_air_in = (J_O2_in + J_N2_in + J_CO2_in) * pant
-  V_air = uconvert(u"m^3/s",(J_air_in * R * 273.15K / 101325Pa)) # air volume @ stp (m3/s)
-  # computing the vapor pressure at saturation for the subsequent calculation of 
-  # actual moles of water based on actual relative humidity
-  wet_air_out = wet_air(T_air, 273.15K, rh, nothing, P_atmos)
-  P_vap_sat = wet_air_out.P_vap_sat
-  J_H2O_in = J_air_in * (P_vap_sat * (rh / 100)) / (P_atmos - P_vap_sat * (rh / 100))
-  # moles at exit
-  J_O2_out = J_O2_in - J_O2 # remove consumed oxygen from the total
-  J_N2_out = J_N2_in
-  J_CO2_out = rq * J_O2 + J_CO2_in
-  # total moles of air at exit will be approximately the same as at entrance, since 
-  # the moles of O2 removed = approx. the # moles of co2 added
-  J_air_out = (J_O2_out + J_N2_out + J_CO2_out) * pant
-  # setting up call to wet_air using temperature of exhaled air at body temperature, assuming saturated air
-  rh_exit = 100
-  wet_air_out = wet_air(T_x, 0K, rh_exit, nothing, P_atmos)
-  P_vap_sat = wet_air_out.P_vap_sat
-  J_H2O_out = J_air_out * (P_vap_sat / (P_atmos - P_vap_sat))
-  # enthalpy = U2-U1, internal energy only, i.e. lat. heat of vap. only involved, since assume 
-  # P,T,V constant, so not significant flow energy, PV. (H = U + PV)
+    T_x=296.15K,
+    Q_metab=0.01241022W,
+    fO2_extract=0.20,
+    pant=1,
+    rq=0.8,
+    T_air=293.15K,
+    rh=50,
+    elev=nothing,
+    P_atmos=101325Pa,
+    fO2=0.2095,
+    fCO2=0.0003,
+    fN2=0.7902)
 
-  # moles/s lost by breathing:
-  J_evap = J_H2O_out - J_H2O_in
-  # grams/s lost by breathing = moles lost * gram molecular weight of water:
-  m_resp = J_evap * 18g/mol
-  # get latent heat of vapourisation and compute heat exchange due to respiration
-  L_v = (2.5012e6 - 2.3787e3 * (Unitful.ustrip(T_lung)-273.15))J/kg # from dry_air
-  # heat loss by breathing (J/s)=(J/kg)*(kg/s)
-  Q_resp = uconvert(u"W",L_v * m_resp)
-  (Q_resp = Q_resp, m_resp = m_resp, J_air_in = J_air_in, J_air_out = J_air_out, J_H2O_in = J_H2O_in, J_H2O_out = J_H2O_out, J_O2_in = J_O2_in, J_O2_out = J_O2_out, J_CO2_in = J_CO2_in, J_CO2_out = J_CO2_out)
+    # adjust O2 to ensure sum to 1
+    if fO2 + fCO2 + fN2 != 1
+        fO2 = 1 - (fN2 + fCO2)
+    end
+    P_O2 = P_atmos * fO2
+    Joule_m3_O2 = 20.1e6J / m^3 # joules of energy dissipated per m3 O2 consumed at STP (enthalpy of combustion)
+    V_O2_STP = uconvert(u"m^3/s", Q_metab / Joule_m3_O2)
+
+    # converting stp -> vol. of O2 at animal lung temperature, atm. press.
+    T_lung = T_x
+    V_O2 = (V_O2_STP * P_O2 / 273.15K) * (T_lung / P_O2)
+    #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
+    J_O2 = uconvert(u"mol/s", P_atmos * V_O2 / (R * T_x)) # mol O2 consumed
+    # moles/s of O2, N2, dry air at entrance [air flow = f(O2 consumption)]
+    J_O2_in = J_O2 / fO2_extract # actual oxygen flow in (moles/s), accounting for efficiency of extraction
+    J_N2_in = J_O2_in * (fN2 / fO2) #  actual nitrogen flow in (moles/s), accounting for efficiency of extraction
+    V_air = V_O2 / fO2 # air flow
+    V_CO2 = fCO2 * V_air #O2 flow
+    J_CO2_in = P_atmos * V_CO2 / (R * T_lung)
+    J_air_in = (J_O2_in + J_N2_in + J_CO2_in) * pant
+    V_air = uconvert(u"m^3/s", (J_air_in * R * 273.15K / 101325Pa)) # air volume @ stp (m3/s)
+    # computing the vapor pressure at saturation for the subsequent calculation of 
+    # actual moles of water based on actual relative humidity
+    wet_air_out = wet_air(T_air, 273.15K, rh, nothing, P_atmos)
+    P_vap_sat = wet_air_out.P_vap_sat
+    J_H2O_in = J_air_in * (P_vap_sat * (rh / 100)) / (P_atmos - P_vap_sat * (rh / 100))
+    # moles at exit
+    J_O2_out = J_O2_in - J_O2 # remove consumed oxygen from the total
+    J_N2_out = J_N2_in
+    J_CO2_out = rq * J_O2 + J_CO2_in
+    # total moles of air at exit will be approximately the same as at entrance, since 
+    # the moles of O2 removed = approx. the # moles of co2 added
+    J_air_out = (J_O2_out + J_N2_out + J_CO2_out) * pant
+    # setting up call to wet_air using temperature of exhaled air at body temperature, assuming saturated air
+    rh_exit = 100
+    wet_air_out = wet_air(T_x, 0K, rh_exit, nothing, P_atmos)
+    P_vap_sat = wet_air_out.P_vap_sat
+    J_H2O_out = J_air_out * (P_vap_sat / (P_atmos - P_vap_sat))
+    # enthalpy = U2-U1, internal energy only, i.e. lat. heat of vap. only involved, since assume 
+    # P,T,V constant, so not significant flow energy, PV. (H = U + PV)
+
+    # moles/s lost by breathing:
+    J_evap = J_H2O_out - J_H2O_in
+    # grams/s lost by breathing = moles lost * gram molecular weight of water:
+    m_resp = J_evap * 18g / mol
+    # get latent heat of vapourisation and compute heat exchange due to respiration
+    L_v = (2.5012e6 - 2.3787e3 * (Unitful.ustrip(T_lung) - 273.15))J / kg # from dry_air
+    # heat loss by breathing (J/s)=(J/kg)*(kg/s)
+    Q_resp = uconvert(u"W", L_v * m_resp)
+    (Q_resp=Q_resp, m_resp=m_resp, J_air_in=J_air_in, J_air_out=J_air_out, J_H2O_in=J_H2O_in, J_H2O_out=J_H2O_out, J_O2_in=J_O2_in, J_O2_out=J_O2_out, J_CO2_in=J_CO2_in, J_CO2_out=J_CO2_out)
 end
 
-function metabolism(mass = 0.04kg, T_core = K(25°C), M1 = 0.013, M2 = 0.8, M3 = 0.038)
+function metabolism(mass=0.04kg, T_core=K(25°C), M1=0.013, M2=0.8, M3=0.038)
     mass_g = uconvert(u"g", mass)
     T_core = uconvert(u"°C", T_core)
-    T_core > 50°C && return (0.0056 * M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * 50))W
-    T_core < 1°C && return 0.01W
-    (0.0056 * M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * Unitful.ustrip(T_core)))W
+    if T_core > 50°C
+        V_O2 = M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * 50)
+    else
+        V_O2 = M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * Unitful.ustrip(T_core))
+    end
+    if T_core < 1°C
+        Q_metab = 0.01W
+    else
+        Q_metab = (0.0056 * V_O2)W
+    end
+    V_O2 = (V_O2)ml / hr
+    (Q_metab=Q_metab, V_O2=V_O2)
 end
 
 get_Tsurf_Tlung(body::AbstractBody, k_body, Q_gen_spec, T_core) = get_Tsurf_Tlung(shape(body), body, k_body, Q_gen_spec, T_core)

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -1,6 +1,3 @@
-using Unitful
-using Unitful: °, rad, °C, K, Pa, kPa, MPa, J, kJ, W, L, g, kg, cm, m, s, hr, d, mol, mmol, μmol, σ, R
-
 # Biophysics
 """
     vapour_pressure
@@ -94,7 +91,7 @@ function wet_air(T_drybulb, T_wetbulb=T_drybulb, rh=0, T_dew=nothing, P_atmos=10
 end
 
 function dry_air(T_drybulb, P_atmos=nothing, elev=0m)
-    σ = Unitful.k^4*π^2/(60*Unitful.ħ^3*Unitful.c0^2) # Stefan-Boltzmann constant, W/m^2/K^4, make Unitful.σ when error is fixed in Unitful
+    σ = Unitful.uconvert(u"W/m^2/K^4",Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
     M_a = 0.028965924869122257kg/mol # molar mass of air
     if P_atmos === nothing
      P_std = 101325Pa
@@ -202,11 +199,11 @@ function get_Nusselt_forced(shape::Ellipsoid, Re)
 end
 
 function water_prop(T_water)
-  # C     β = COEFFICIENT OF EXPANSION (1/C)
-  # C     cp_fluid = SPECIFIC HEAT (J/KG-C)
-  # C     ρ_air = WATER DENSITY (KG/M3)
-  # C     k_fluid = THERMAL CONDUCTIVITY (W/M-C)
-  # C     μ = DYNAMIC VISCOSITY (KG/M-S)
+  #     β = COEFFICIENT OF EXPANSION (1/C)
+  #     cp_fluid = SPECIFIC HEAT (J/KG-C)
+  #     ρ_air = WATER DENSITY (KG/M3)
+  #     k_fluid = THERMAL CONDUCTIVITY (W/M-C)
+  #     μ = DYNAMIC VISCOSITY (KG/M-S)
   β = 0.21E-031/K
   T_water = Unitful.ustrip(T_water)-273.15
   cp_fluid = 4220.02 - 4.5531 * T_water + 0.182958  * T_water ^ 2 - 0.00310614 *  T_water ^ 3 + 1.89399E-5 * T_water ^ 4
@@ -227,11 +224,10 @@ end
   (β = β, cp_fluid = cp_fluid, ρ_water = ρ_water, k_fluid = k_fluid, μ = μ)
 end
 
-function convection(Body, area, T_air, T_surf, vel, P_atmos, elev, fluid)
+function convection(Body, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
     shape = Body.geometry
     G = Unitful.gn # acceleration due to gravity, m.s^2
     β = 1 / T_air
-    A_conv = area # m2
     D = shape.characteristic_dimension
     dry_air_out = dry_air(T_air, P_atmos, elev)
     dif_vpr = dry_air_out.dif_vpr
@@ -305,32 +301,32 @@ function radin(A_tot = 0.01325006m^2,
     T_sky = (10+273.15)K,
     T_sub = (30+273.15)K)
 
-σ = Unitful.k^4*π^2/(60*Unitful.ħ^3*Unitful.c0^2) # Stefan-Boltzmann constant, W/m^2/K^4, make Unitful.σ when error is fixed in Unitful
+    σ = Unitful.uconvert(u"W/m^2/K^4",Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
 Q_ir_sky = ϵ_org_dorsal * F_sky * A_tot * ϵ_sky * σ * T_sky ^ 4
 Q_ir_sub = ϵ_org_ventral * F_sub * A_tot * ϵ_sub * σ * T_sub ^ 4
 (Q_ir_sky + Q_ir_sub)
 end
 
 function radout(
-    T_skin = (25.1+273.15)K,
+    T_surf = (25.1+273.15)K,
     A_tot = 0.01325006m^2,
     F_sky = 0.4,
     F_sub = 0.4,
     ϵ_org_dorsal = 0.95,
     ϵ_org_ventral = 0.95)
-# C     COMPUTES LONGWAVE RADIATION LOST
-σ = Unitful.k^4*π^2/(60*Unitful.ħ^3*Unitful.c0^2) # Stefan-Boltzmann constant, W/m^2/K^4, make Unitful.σ when error is fixed in Unitful
-Q_ir_to_sky = A_tot * F_sky * ϵ_org_dorsal * σ  * T_skin ^ 4
-Q_ir_to_sub = A_tot * F_sub * ϵ_org_ventral * σ  * T_skin ^ 4
+#     COMPUTES LONGWAVE RADIATION LOST
+σ = Unitful.uconvert(u"W/m^2/K^4",Unitful.σ) # Stefan-Boltzmann constant, W/m^2/K^4, extract σ when calling Unitful when units issue is fixed in Unitful
+Q_ir_to_sky = A_tot * F_sky * ϵ_org_dorsal * σ  * T_surf ^ 4
+Q_ir_to_sub = A_tot * F_sub * ϵ_org_ventral * σ  * T_surf ^ 4
 (Q_ir_to_sky + Q_ir_to_sub)
 end
 
 function evaporation(
     T_core = (25+273.15)K,
-    T_skin = (25.1+273.15)K,
+    T_surf = (25.1+273.15)K,
     m_resp = 1.177235e-09kg/s,
     ψ_org = -7.07 * 100J/kg,
-    p_wet = 0.1,
+    p_wet = 0.1 / 100,
     A_tot = 0.01325006m^2,
     Hd = 0.02522706m/s,
     p_eyes = 0.03 / 100,
@@ -339,25 +335,25 @@ function evaporation(
     elev = 0m,
     P_atmos = 101325Pa)
     
-  # C     THIS SUBROUTINE COMPUTES SURFACE EVAPORATION BASED ON THE MASS TRANSFER
-  # C     COEFFICIENT, % OF SURFACE OF THE SKIN ACTING AS A FREE WATER SURFACE
-  # C     AND EXPOSED TO THE AIR, AND THE VAPOR DENSITY GRADIENT BETWEEN THE
-  # C     SURFACE AND THE AIR, EACH AT THEIR OWN TEMPERATURE.
+  #     THIS SUBROUTINE COMPUTES SURFACE EVAPORATION BASED ON THE MASS TRANSFER
+  #     COEFFICIENT, % OF SURFACE OF THE SKIN ACTING AS A FREE WATER SURFACE
+  #     AND EXPOSED TO THE AIR, AND THE VAPOR DENSITY GRADIENT BETWEEN THE
+  #     SURFACE AND THE AIR, EACH AT THEIR OWN TEMPERATURE.
 
   # get vapour density at surface based on water potential of body
   m_w = 0.018kg/mol #! molar mass of water, kg/mol
-  rh_surf = exp(ψ_org / (Unitful.R / m_w * T_skin)) * 100 #
-  wet_air_out = wet_air(T_skin, 0K, rh_surf, 999K, P_atmos)
+  rh_surf = exp(ψ_org / (Unitful.R / m_w * T_surf)) * 100 #
+  wet_air_out = wet_air(T_surf, 0K, rh_surf, nothing, P_atmos)
   ρ_vap_surf = wet_air_out.ρ_vap
 
   # get air vapour density
-  wet_air_out = wet_air(T_air, 0K, rh, 999K, P_atmos)
+  wet_air_out = wet_air(T_air, 0K, rh, nothing, P_atmos)
   ρ_vap_air = wet_air_out.ρ_vap
 
   # water lost from eyes if present
   m_eyes = Hd * p_eyes * A_tot * (ρ_vap_surf - ρ_vap_air)
   if m_eyes > 0kg/s
-    m_cut = A_tot * p_wet * (1 - p_eyes) * Hd * (ρ_vap_surf - ρ_vap_air)
+    m_cut = (A_tot * p_wet  - A_tot * p_wet * p_eyes) * Hd * (ρ_vap_surf - ρ_vap_air)
   else
     m_cut = A_tot * p_wet * Hd * (ρ_vap_surf - ρ_vap_air)
   end
@@ -368,9 +364,9 @@ function evaporation(
   # get latent heat of vapourisation and compute heat exchange due to evaporation
   dry_air_out = dry_air(T_air, P_atmos, elev)
   L_v = dry_air_out.L_v
-  Q_evap = (m_eyes + m_cut) * L_v
+  Q_evap = Unitful.uconvert(u"W",(m_eyes + m_cut) * L_v)
   
-  # convert from kg/s to g/s
+  #onvert from kg/s to g/s
   m_eyes = uconvert(u"g/s",m_eyes)
   m_resp = uconvert(u"g/s",m_resp)
   m_cut = uconvert(u"g/s",m_cut)
@@ -391,7 +387,7 @@ if atmospheric pressure is unknown, elevation will be used to estimate it.
     # Arguments
     - `T_x`: current core temperature guess, K
     - `Q_metab`: metabolic rate, W
-    - `fO2_ext`: extraction efficiency, fractional
+    - `fO2_extract`: extraction efficiency, fractional
     - `pant`: multiplier on breathing rate due to panting, -
     - `rq`: respiratory quotient, (mol CO2 / mol O2)
     - `T_air`: air temperature, K
@@ -406,7 +402,7 @@ if atmospheric pressure is unknown, elevation will be used to estimate it.
 function respiration(
     T_x = 296.15K,
     Q_metab = 0.01241022W,
-    fO2_ext = 0.20,
+    fO2_extract = 0.20,
     pant = 1,
     rq = 0.8,
     T_air = 293.15K,
@@ -425,22 +421,22 @@ function respiration(
   Joule_m3_O2 = 20.1e6J/m^3 # joules of energy dissipated per m3 O2 consumed at STP (enthalpy of combustion)
   V_O2_STP = uconvert(u"m^3/s", Q_metab / Joule_m3_O2)
   
-  # converting stp -> vol. of O2 at animal lung temperature, atm. press.
+  #onverting stp -> vol. of O2 at animal lung temperature, atm. press.
   T_lung = T_x
   V_O2 = (V_O2_STP * P_O2 / 273.15K) * (T_lung / P_O2)
   #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
   J_O2 = uconvert(u"mol/s", P_atmos * V_O2 / (R * T_x)) # mol O2 consumed
   # moles/s of O2, N2, dry air at entrance [air flow = f(O2 consumption)]
-  J_O2_in = J_O2 / fO2_ext # actual oxygen flow in (moles/s), accounting for efficiency of extraction
+  J_O2_in = J_O2 / fO2_extract # actual oxygen flow in (moles/s), accounting for efficiency of extraction
   J_N2_in = J_O2_in * (fN2 / fO2) #  actual nitrogen flow in (moles/s), accounting for efficiency of extraction
   V_air = V_O2 / fO2 # air flow
-  V_CO2 = fCO2 * V_air # CO2 flow
+  V_CO2 = fCO2 * V_air #O2 flow
   J_CO2_in = P_atmos * V_CO2 / (R * T_lung)
   J_air_in = (J_O2_in + J_N2_in + J_CO2_in) * pant
   V_air = uconvert(u"m^3/s",(J_air_in * R * 273.15K / 101325Pa)) # air volume @ stp (m3/s)
-  # computing the vapor pressure at saturation for the subsequent calculation of 
+  #omputing the vapor pressure at saturation for the subsequent calculation of 
   # actual moles of water based on actual relative humidity
-  wet_air_out = wet_air(T_air, 0K, rh, 999K, P_atmos)
+  wet_air_out = wet_air(T_air, 0K, rh, nothing, P_atmos)
   P_vap_sat = wet_air_out.P_vap_sat
   J_H2O_in = J_air_in * (P_vap_sat * (rh / 100)) / (P_atmos - P_vap_sat * (rh / 100))
   # moles at exit
@@ -452,7 +448,7 @@ function respiration(
   J_air_out = (J_O2_out + J_N2_out + J_CO2_out) * pant
   # setting up call to wet_air using temperature of exhaled air at body temperature, assuming saturated air
   rh_exit = 100
-  wet_air_out = wet_air(T_x, 0K, rh_exit, 999K, P_atmos)
+  wet_air_out = wet_air(T_x, 0K, rh_exit, nothing, P_atmos)
   P_vap_sat = wet_air_out.P_vap_sat
   J_H2O_out = J_air_out * (P_vap_sat / (P_atmos - P_vap_sat))
   # enthalpy = U2-U1, internal energy only, i.e. lat. heat of vap. only involved, since assume 
@@ -476,4 +472,46 @@ function metabolism(mass = 0.04kg, T_core = K(25°C), M1 = 0.013, M2 = 0.8, M3 =
     T_core > 50°C && return (0.0056 * M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * 50))W
     T_core < 1°C && return 0.01W
     (0.0056 * M1 * Unitful.ustrip(mass_g)^M2 * 10^(M3 * Unitful.ustrip(T_core)))W
+end
+
+get_Tsurf_Tlung(body::AbstractBody, k_body, Q_gen_spec, T_core) = get_Tsurf_Tlung(shape(body), body, k_body, Q_gen_spec, T_core)
+
+function get_Tsurf_Tlung(shape::Cylinder, body, k_body, Q_gen_spec, T_core)
+    # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
+    R_flesh = body.geometry.lengths[2]
+    T_surf = T_core - Q_gen_spec * R_flesh ^ 2 / (4 * k_body)
+    T_lung = (Q_gen_spec * R_flesh ^ 2) / (8 * k_body) + T_surf 
+    (T_surf = T_surf, T_lung = T_lung)  
+end
+
+function get_Tsurf_Tlung(shape::Ellipsoid, body, k_body, Q_gen_spec, T_core)
+    a = body.geometry.lengths[1] ^ 2
+    b = body.geometry.lengths[2] ^ 2
+    c = body.geometry.lengths[3] ^ 2
+    T_surf = T_core - (Q_gen_spec / (2 * k_body)) * ((a * b * c) / (a * b + a * c + b * c))
+    T_lung = (Q_gen_spec / (4 * k_body)) * ((a * b * c) / (a * b + a * c + b * c)) + T_surf
+    (T_surf = T_surf, T_lung = T_lung)  
+end
+
+#= function get_Tsurf_Tlung(shape::Sphere, body, k_body, Q_gen_spec, T_core)
+    R_flesh = body.geometry.lengths[2]
+    T_surf = T_core - (Q_gen_spec * R_flesh ^ 2) / (6 * k_body)
+    T_lung = (Q_gen_spec * R_flesh ^ 2) / (12 * k_body) + T_surf
+    (T_surf = T_surf, T_lung = T_lung) 
+end =#
+
+function get_Tsurf_Tlung(shape::DesertIguana, body, k_body, Q_gen_spec, T_core)
+    # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
+    R_flesh = body.geometry.lengths[2]
+    T_surf = T_core - Q_gen_spec * R_flesh ^ 2 / (4 * k_body)
+    T_lung = (Q_gen_spec * R_flesh ^ 2) / (8 * k_body) + T_surf 
+    (T_surf = T_surf, T_lung = T_lung)  
+end
+
+function get_Tsurf_Tlung(shape::LeopardFrog, body, k_body, Q_gen_spec, T_core)
+    # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
+    R_flesh = body.geometry.lengths[2]
+    T_surf = T_core - Q_gen_spec * R_flesh ^ 2 / (4 * k_body)
+    T_lung = (Q_gen_spec * R_flesh ^ 2) / (8 * k_body) + T_surf 
+    (T_surf = T_surf, T_lung = T_lung)  
 end

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -20,6 +20,7 @@ Base.@kwdef struct EnvironmentalVars{T,R,V,Z,K,Q}
     vel::V = 1m/s
     zen::Z = 20°
     k_sub::K = 0.5W/m/K
-    Q_dir::Q = 1000W/m^2
-    Q_dif::Q = 200W/m^2
+    Q_sol::Q = 1000W/m^2
+    Q_dir::Q = 964W/m^2
+    Q_dif::Q = 100W/m^2
 end

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -1,9 +1,8 @@
 
-Base.@kwdef mutable struct EnvironmentalParams{A,P,E,L,F}
+Base.@kwdef struct EnvironmentalParams{A,E,L,F}
     α_sub::A = Param(0.2, bounds=(0.0, 1.0))
     ϵ_sub::A = Param(1.0, bounds=(0.2, 1.0))
     ϵ_sky::A = Param(1.0, bounds=(0.2, 1.0))
-    P_atmos::P = Param(101325.0, units=u"Pa")
     elev::E = Param(0.0, units=u"m")
     fluid::L = Param(0)
     fN2::F = Param(0.79)
@@ -12,12 +11,13 @@ Base.@kwdef mutable struct EnvironmentalParams{A,P,E,L,F}
 end
 
 
-Base.@kwdef mutable struct EnvironmentalVars{T,R,V,Z,K,Q}
+Base.@kwdef struct EnvironmentalVars{T,R,V,P,Z,K,Q}
     T_air::T = K(20.0°C)
     T_sky::T = K(-5.0°C)
     T_sub::T = K(30.0°C)
     rh::R = 5.0
     vel::V = 1.0m/s
+    P_atmos::P = 101325.0Pa
     zen::Z = 20.0°
     k_sub::K = 0.5W/m/K
     Q_sol::Q = 1000.0W/m^2

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -13,9 +13,9 @@ end
 
 
 Base.@kwdef struct EnvironmentalVars{T,R,V,Z,K,Q}
-    Ta::T = K(20°C)
-    Tsky::T = K(-5°C)
-    Tsub::T = K(30°C)
+    T_air::T = K(20°C)
+    T_sky::T = K(-5°C)
+    T_sub::T = K(30°C)
     rh::R = 5
     vel::V = 1m/s
     zen::Z = 20°

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -1,26 +1,26 @@
 
-Base.@kwdef struct EnvironmentalParams{A,P,E,L,F}
+Base.@kwdef mutable struct EnvironmentalParams{A,P,E,L,F}
     α_sub::A = Param(0.2, bounds=(0.0, 1.0))
     ϵ_sub::A = Param(1.0, bounds=(0.2, 1.0))
     ϵ_sky::A = Param(1.0, bounds=(0.2, 1.0))
-    P_atmos::P = Param(101325, units=u"Pa")
-    elev::E = Param(0, units=u"m")
+    P_atmos::P = Param(101325.0, units=u"Pa")
+    elev::E = Param(0.0, units=u"m")
     fluid::L = Param(0)
     fN2::F = Param(0.79)
     fO2::F = Param(0.2095)
-    fCO2::F = Param(0.00042)
+    fCO2::F = Param(0.0003)
 end
 
 
-Base.@kwdef struct EnvironmentalVars{T,R,V,Z,K,Q}
-    T_air::T = K(20°C)
-    T_sky::T = K(-5°C)
-    T_sub::T = K(30°C)
-    rh::R = 5
-    vel::V = 1m/s
-    zen::Z = 20°
+Base.@kwdef mutable struct EnvironmentalVars{T,R,V,Z,K,Q}
+    T_air::T = K(20.0°C)
+    T_sky::T = K(-5.0°C)
+    T_sub::T = K(30.0°C)
+    rh::R = 5.0
+    vel::V = 1.0m/s
+    zen::Z = 20.0°
     k_sub::K = 0.5W/m/K
-    Q_sol::Q = 1000W/m^2
-    Q_dir::Q = 964W/m^2
-    Q_dif::Q = 100W/m^2
+    Q_sol::Q = 1000.0W/m^2
+    Q_dir::Q = 964.177772475912W/m^2
+    Q_dif::Q = 100.0W/m^2
 end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -167,40 +167,50 @@ end
 #     return Geometry(volume, length, (length1, length2, length3), area)
 # end
 function calc_area(shape::Ellipsoid, a, b, c)
-    e = ((a ^ 2 - c ^ 2) ^ 0.5 ) / a # eccentricity
-    2 * π * b ^ 2 + 2 * π * (a * b / e) * asin(e)
+    #e = ((a ^ 2 - c ^ 2) ^ 0.5 ) / a # eccentricity
+    #2 * π * b ^ 2 + 2 * π * (a * b / e) * asin(e)
+    p =  1.6075
+    (4 * π * (((a ^ p * b ^ p + a ^ p * c ^ p + b ^ p * c ^ p)) / 3) ^ (1 / p))
 end
 function calc_area(shape::Ellipsoid, body)
     a = body.geometry.lengths[1] / 2
     b = body.geometry.lengths[2] / 2
     c = body.geometry.lengths[3] / 2
-    e = ((a ^ 2 - c ^ 2) ^ 0.5 ) / a # eccentricity
-    2 * π * b ^ 2 + 2 * π * (a * b / e) * asin(e)
+    p =  1.6075
+    (4 * π * (((a ^ p * b ^ p + a ^ p * c ^ p + b ^ p * c ^ p)) / 3) ^ (1 / p))
+    # e = ((a ^ 2 - c ^ 2) ^ 0.5 ) / a # eccentricity
+    # 2 * π * b ^ 2 + 2 * π * (a * b / e) * asin(e)
 end
 
-"""
-    sil_area_of_ellipsoid
+# """
+#     sil_area_of_ellipsoid
 
-Calculates the silhouette (projected) area of a prolate spheroid.
-"""
-function calc_silhouette_area(shape::Ellipsoid, a, b, c, θ)
-    a2 = cos(90) ^ 2 * (cos(θ) ^ 2 / a ^ 2 + sin(θ) ^ 2 / b ^ 2) + sin(90) ^ 2 / c ^ 2
-    twohh = 2 * cos(90) * sin(90) * cos(θ) * (1 / b ^ 2 - 1 / a ^ 2)
-    b2 = sin(θ) ^ 2 / a ^ 2 + cos(θ) ^ 2 / b ^ 2
-    θ2 = 0.5 * atan(twohh, a2 - b2)
-    sps = sin(θ2)
-    cps = cos(θ2)
-    a3 = cps * (a2 * cps + twohh * sps) + b2 * sps * sps
-    b3 = sps * (a2 * sps - twohh * cps) + b2 * cps * cps
-    semax1 = 1 / sqrt(a3)
-    semax2 = 1 / sqrt(b3)
-    π * semax1  * semax2
-end
+# Calculates the silhouette (projected) area of a prolate spheroid.
+# """
+# function calc_silhouette_area(shape::Ellipsoid, a, b, c, θ)
+#     a2 = cos(90) ^ 2 * (cos(θ) ^ 2 / a ^ 2 + sin(θ) ^ 2 / b ^ 2) + sin(90) ^ 2 / c ^ 2
+#     twohh = 2 * cos(90) * sin(90) * cos(θ) * (1 / b ^ 2 - 1 / a ^ 2)
+#     b2 = sin(θ) ^ 2 / a ^ 2 + cos(θ) ^ 2 / b ^ 2
+#     θ2 = 0.5 * atan(twohh, a2 - b2)
+#     sps = sin(θ2)
+#     cps = cos(θ2)
+#     a3 = cps * (a2 * cps + twohh * sps) + b2 * sps * sps
+#     b3 = sps * (a2 * sps - twohh * cps) + b2 * cps * cps
+#     semax1 = 1 / sqrt(a3)
+#     semax2 = 1 / sqrt(b3)
+#     π * semax1  * semax2
+# end
+# function calc_silhouette_area(shape::Ellipsoid, body, θ)
+#     a = body.geometry.lengths[1] / 2
+#     b = body.geometry.lengths[2] / 2
+#     c = body.geometry.lengths[3] / 2
+#     calc_silhouette_area(shape, a, b, c, θ)
+# end
 function calc_silhouette_area(shape::Ellipsoid, body, θ)
     a = body.geometry.lengths[1] / 2
     b = body.geometry.lengths[2] / 2
     c = body.geometry.lengths[3] / 2
-    calc_silhouette_area(shape, a, b, c, θ)
+    max(π * a * c, π * b * c)
 end
 
 """

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -1,6 +1,3 @@
-using Unitful
-using Unitful: °, rad, °C, K, Pa, kPa, MPa, J, kJ, W, L, g, kg, cm, m, s, hr, d, mol, mmol, μmol, σ, R
-
 """
     Shape
 
@@ -161,7 +158,7 @@ function geometry(shape::Ellipsoid, ::Naked)
     length1 = a * 2m
     length2 = b * 2m
     length3 = c * 2m
-    area = calc_area(shape, a, b, c)
+    area = calc_area(shape, a, b, c)m^2
     return Geometry(volume, length, (length1, length2, length3), area)
 end
 # function geometry(shape::Ellipsoid, fur::Fur)

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -3,10 +3,11 @@
 
 function heat_balance() end
 # A method dispatching on a `Model`
-heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripparams(e_params), vars)heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
+heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripparams(e_params), vars)
+heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
 # A generic method that expands dispatch to include the insulation
 # this could be <:Ectotherm or <:Endotherm?
-heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
+#heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
 # A method for Naked organisms
 
 function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
@@ -15,11 +16,9 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     
     # compute areas for exchange
     A_tot = o.body.geometry.area
-    A_c = A_tot * (1 - o_vars.p_cond)
-    A_v = A_tot * o_vars.p_cond
+    A_conv = A_tot * (1 - o_vars.p_cond)
+    A_cond = A_tot * o_vars.p_cond
     A_sil = calc_silhouette_area(o.body, e_vars.zen)
-    A_up = A_tot / 2
-    A_down = A_tot / 2
 
     # calculate heat fluxes
     Q_metab = metabolism(o.body.shape.mass, T_x, pars.M1, pars.M2, pars.M3)
@@ -30,13 +29,13 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     Tsurf_Tlung_out = get_Tsurf_Tlung(o.body, pars.k_body, Q_gen_spec, T_x)
     T_surf = Tsurf_Tlung_out.T_surf
     #T_lung = Tsurf_Tlung_out.T_lung
-    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_up, A_down, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_dir, e_vars.Q_dif)
-    Q_IR_in = radin(A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
-    Q_IR_out = radout(T_surf, A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
+    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_tot, A_cond, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_sol, e_vars.Q_dir, e_vars.Q_dif)
+    Q_IR_in = radin(A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
+    Q_IR_out = radout(T_surf, A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
     Le = 0.025m
-    Q_cond = conduction(A_v, Le, T_surf, e_vars.Tsub, e_vars.k_sub)
-    conv_out = convection(o.body, A_c, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
-    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, o_vars.p_wet, A_c, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_pars.P_atmos)
+    Q_cond = conduction(A_cond, Le, T_surf, e_vars.Tsub, e_vars.k_sub)
+    conv_out = convection(o.body, A_conv, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
+    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, o_vars.p_wet, A_conv, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_pars.P_atmos)
     Q_conv = conv_out.Q_conv # convective heat loss
     Q_evap = evap_out.Q_evap # evaporative heat loss
     
@@ -53,10 +52,8 @@ end
 function heat_balance(T_x)
 
     # compute areas for exchange
-    A_c = A_tot * (1 - p_cond)
+    A_conv = A_tot * (1 - p_cond)
     A_sil = calc_silhouette_area(body_organism, Z)
-    A_up = A_tot / 2
-    A_down = A_tot / 2
 
     # calculate heat fluxes
     Q_metab = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
@@ -68,12 +65,12 @@ function heat_balance(T_x)
     T_surf = Tsurf_Tlung_out.T_surf
     #T_lung = Tsurf_Tlung_out.T_lung
     #Q_norm = Q_dir / cos(Z)
-    Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
-    Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
-    Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
-    Q_cond = conduction(A_v, Le, T_surf, T_sub, k_sub)
-    conv_out = convection(body_organism, A_c, T_air, T_surf, vel, P_atmos, elev, fluid)
-    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_c, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
+    Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_tot, A_cond, F_sub, F_sky, α_sub, Q_sol, Q_dir, Q_dif)
+    Q_IR_in = radin(A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
+    Q_IR_out = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
+    Q_cond = conduction(A_cond, Le, T_surf, T_sub, k_sub)
+    conv_out = convection(body_organism, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
+    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_conv, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
     Q_conv = conv_out.Q_conv
     Q_evap = evap_out.Q_evap
 

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -7,7 +7,7 @@ heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripp
 heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
 # A generic method that expands dispatch to include the insulation
 # this could be <:Ectotherm or <:Endotherm?
-#heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
+heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
 # A method for Naked organisms
 
 function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
@@ -28,12 +28,13 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     Q_gen_spec = Q_gen_net / o.body.geometry.volume
     Tsurf_Tlung_out = get_Tsurf_Tlung(o.body, pars.k_body, Q_gen_spec, T_x)
     T_surf = Tsurf_Tlung_out.T_surf
+    
     #T_lung = Tsurf_Tlung_out.T_lung
     Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_tot, A_cond, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_sol, e_vars.Q_dir, e_vars.Q_dif)
     Q_IR_in = radin(A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
     Q_IR_out = radout(T_surf, A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
     Le = 0.025m
-    Q_cond = conduction(A_cond, Le, T_surf, e_vars.Tsub, e_vars.k_sub)
+    Q_cond = conduction(A_cond, Le, T_surf, e_vars.T_sub, e_vars.k_sub)
     conv_out = convection(o.body, A_conv, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
     evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, o_vars.p_wet, A_conv, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_pars.P_atmos)
     Q_conv = conv_out.Q_conv # convective heat loss

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -88,23 +88,29 @@ function heat_balance(T_x)
     A_up = A_tot / 2
     A_down = A_tot / 2
 
-    Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, α_sub, F_sub, F_sky, Q_dir, Q_dif)
+    # calculate heat fluxes
+    Q_metab = metabolism(mass_organism, T_x, M1, M2, M3)
+    resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
+    Q_resp = resp_out.Q_resp
+    Q_gen_net = Q_metab - Q_resp
+    Q_gen_spec = Q_gen_net / body_organism.geometry.volume
+    Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_x)
+    T_surf = Tsurf_Tlung_out.T_surf
+    T_lung = Tsurf_Tlung_out.T_lung
+    Q_norm = Q_dir / cos(Z)
+    Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
     Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
-    Q_IR_out = radout(T_x, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
-    Q_metab = metabolism(body_organism.shape.mass, T_core, M1, M2, M3)
-    Le = 0.025m
+    Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
+    Q_metab = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
     Q_cond = conduction(A_v, Le, T_surf, T_sub, k_sub)
-    
-    conv_out = convection(body_organism, A_c, T_air, T_x, vel, P_atmos, elev, fluid)
-    resp_out = respiration(T_x, Q_metab, fO2_ext, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
-    m_resp = resp_out.m_resp
-    evap_out = evaporation(T_x, T_surf, m_resp, ψ_org, p_wet, A_tot, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
+    conv_out = convection(body_organism, A_c, T_air, T_surf, vel, P_atmos, elev, fluid)
+    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_c, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
+    Q_conv = conv_out.Q_conv
+    Q_evap = evap_out.Q_evap
+    Q_resp = resp_out.Q_resp
 
-    Q_conv = conv_out.Q_conv # convective heat loss
-    Q_evap = evap_out.Q_evap # evaporative heat loss
-
-    Q_in = Q_solar + Q_IR_in # energy in
-    Q_out = Q_IR_out + Q_conv + Q_evap # energy out
+    Q_in = Q_solar + Q_IR_in + Q_metab # energy in
+    Q_out = Q_IR_out + Q_conv + Q_evap + Q_cond + Q_resp # energy out
     Q_in - Q_out # this must balance
 
 end

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -3,46 +3,12 @@
 
 function heat_balance() end
 # A method dispatching on a `Model`
-heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripparams(e_params), vars)
-heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
+heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripparams(e_params), vars)heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
 # A generic method that expands dispatch to include the insulation
 # this could be <:Ectotherm or <:Endotherm?
-heat_balance(o::Organism, e_pars, vars) = heat_balance(insulation(o), o, params(o), e_pars, vars)
 heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
 # A method for Naked organisms
-function heat_balance(insulation::Naked, o, pars, e_pars, vars)
-    o_vars = vars.organism # make small function to get this
-    e_vars = vars.environment # make small function to get this
-    
-    T_x = o_vars.T_surf
-    # compute areas for exchange
-    A_tot = o.body.geometry.area
-    A_c = A_tot * (1 - o_vars.p_cond)
-    A_v = A_tot * o_vars.p_cond
-    A_sil = calc_silhouette_area(o.body, e_vars.zen)
-    A_up = A_tot / 2
-    A_down = A_tot / 2
 
-    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_up, A_down, e_pars.α_sub, pars.F_sub, pars.F_sky, e_vars.Q_dir, e_vars.Q_dif)
-    Q_IR_in = radin(A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.Tsky, e_vars.Tsub)
-    Q_IR_out = radout(T_x, A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
-    Q_metab = metabolism(o.body.shape.mass, o_vars.T_core, pars.M1, pars.M2, pars.M3)
-    Le = 0.025m
-    Q_cond = conduction(A_v, Le, o_vars.T_surf, e_vars.Tsub, e_vars.k_sub)
-    
-    conv_out = convection(o.body, A_c, e_vars.Ta, T_x, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
-    resp_out = respiration(T_x, Q_metab, pars.fO2_ext, o_vars.pant, pars.rq, e_vars.Ta, e_vars.rh, e_pars.elev, e_pars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
-    m_resp = resp_out.m_resp
-    evap_out = evaporation(T_x, o_vars.T_surf, m_resp, o_vars.ψ_org, o_vars.p_wet, A_tot, conv_out.Hd, pars.p_eyes, e_vars.Ta, e_vars.rh, e_pars.P_atmos)
-
-    Q_conv = conv_out.Q_conv # convective heat loss
-    Q_evap = evap_out.Q_evap # evaporative heat loss
-    Q_resp = resp_out.Q_resp
-
-    Q_in = Q_solar + Q_IR_in + Q_metab # energy in
-    Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
-    Q_in - Q_out # this must balance
-end
 function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     o_vars = vars.organism # make small function to get this
     e_vars = vars.environment # make small function to get this
@@ -55,22 +21,26 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     A_up = A_tot / 2
     A_down = A_tot / 2
 
-    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_up, A_down, e_pars.α_sub, pars.F_sub, pars.F_sky, e_vars.Q_dir, e_vars.Q_dif)
-    Q_IR_in = radin(A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.Tsky, e_vars.Tsub)
-    Q_IR_out = radout(T_x, A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
-    Q_metab = metabolism(o.body.shape.mass, o_vars.T_core, pars.M1, pars.M2, pars.M3)
+    # calculate heat fluxes
+    Q_metab = metabolism(o.body.shape.mass, T_x, pars.M1, pars.M2, pars.M3)
+    resp_out = respiration(T_x, Q_metab, pars.fO2_extract, o_vars.pant, pars.rq, e_vars.T_air, e_vars.rh, e_pars.elev, e_pars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
+    Q_resp = resp_out.Q_resp
+    Q_gen_net = Q_metab - Q_resp
+    Q_gen_spec = Q_gen_net / o.body.geometry.volume
+    Tsurf_Tlung_out = get_Tsurf_Tlung(o.body, pars.k_body, Q_gen_spec, T_x)
+    T_surf = Tsurf_Tlung_out.T_surf
+    #T_lung = Tsurf_Tlung_out.T_lung
+    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_up, A_down, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_dir, e_vars.Q_dif)
+    Q_IR_in = radin(A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
+    Q_IR_out = radout(T_surf, A_tot, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
     Le = 0.025m
-    Q_cond = conduction(A_v, Le, o_vars.T_surf, e_vars.Tsub, e_vars.k_sub)
-    
-    conv_out = convection(o.body, A_c, e_vars.Ta, T_x, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
-    resp_out = respiration(T_x, Q_metab, pars.fO2_ext, o_vars.pant, pars.rq, e_vars.Ta, e_vars.rh, e_pars.elev, e_pars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
-    m_resp = resp_out.m_resp
-    evap_out = evaporation(T_x, o_vars.T_surf, m_resp, o_vars.ψ_org, o_vars.p_wet, A_tot, conv_out.Hd, pars.p_eyes, e_vars.Ta, e_vars.rh, e_pars.P_atmos)
-
+    Q_cond = conduction(A_v, Le, T_surf, e_vars.Tsub, e_vars.k_sub)
+    conv_out = convection(o.body, A_c, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
+    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, o_vars.p_wet, A_c, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_pars.P_atmos)
     Q_conv = conv_out.Q_conv # convective heat loss
     Q_evap = evap_out.Q_evap # evaporative heat loss
-    Q_resp = resp_out.Q_resp
-
+    
+    # calculate balance
     Q_in = Q_solar + Q_IR_in + Q_metab # energy in
     Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
     Q_in - Q_out # this must balance
@@ -89,28 +59,26 @@ function heat_balance(T_x)
     A_down = A_tot / 2
 
     # calculate heat fluxes
-    Q_metab = metabolism(mass_organism, T_x, M1, M2, M3)
+    Q_metab = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
     resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
     Q_resp = resp_out.Q_resp
     Q_gen_net = Q_metab - Q_resp
     Q_gen_spec = Q_gen_net / body_organism.geometry.volume
     Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_x)
     T_surf = Tsurf_Tlung_out.T_surf
-    T_lung = Tsurf_Tlung_out.T_lung
-    Q_norm = Q_dir / cos(Z)
+    #T_lung = Tsurf_Tlung_out.T_lung
+    #Q_norm = Q_dir / cos(Z)
     Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
     Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
     Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
-    Q_metab = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
     Q_cond = conduction(A_v, Le, T_surf, T_sub, k_sub)
     conv_out = convection(body_organism, A_c, T_air, T_surf, vel, P_atmos, elev, fluid)
     evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_c, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
     Q_conv = conv_out.Q_conv
     Q_evap = evap_out.Q_evap
-    Q_resp = resp_out.Q_resp
 
+    # calculate balance
     Q_in = Q_solar + Q_IR_in + Q_metab # energy in
-    Q_out = Q_IR_out + Q_conv + Q_evap + Q_cond + Q_resp # energy out
+    Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
     Q_in - Q_out # this must balance
-
 end

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -21,7 +21,8 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     A_sil = calc_silhouette_area(o.body, e_vars.zen)
 
     # calculate heat fluxes
-    Q_metab = metabolism(o.body.shape.mass, T_x, pars.M1, pars.M2, pars.M3)
+    metab_out = metabolism(o.body.shape.mass, T_x, pars.M1, pars.M2, pars.M3)
+    Q_metab = metab_out.Q_metab
     resp_out = respiration(T_x, Q_metab, pars.fO2_extract, o_vars.pant, pars.rq, e_vars.T_air, e_vars.rh, e_pars.elev, e_pars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
     Q_resp = resp_out.Q_resp
     Q_gen_net = Q_metab - Q_resp
@@ -30,9 +31,12 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     T_surf = Tsurf_Tlung_out.T_surf
     
     #T_lung = Tsurf_Tlung_out.T_lung
-    Q_solar = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_tot, A_cond, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_sol, e_vars.Q_dir, e_vars.Q_dif)
-    Q_IR_in = radin(A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
-    Q_IR_out = radout(T_surf, A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
+    solar_out = solar(pars.α_org_dorsal, pars.α_org_ventral, A_sil, A_tot, A_cond, pars.F_sub, pars.F_sky, e_pars.α_sub, e_vars.Q_sol, e_vars.Q_dir, e_vars.Q_dif)
+    Q_solar = solar_out.Q_solar
+    ir_gain = radin(A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral, e_pars.ϵ_sub, e_pars.ϵ_sky, e_vars.T_sky, e_vars.T_sub)
+    Q_ir_in = ir_gain.Q_ir_in
+    ir_loss = radout(T_surf, A_tot, A_cond, pars.F_sky, pars.F_sub, pars.ϵ_org_dorsal, pars.ϵ_org_ventral)
+    Q_ir_out = ir_loss.Q_ir_out
     Le = 0.025m
     Q_cond = conduction(A_cond, Le, T_surf, e_vars.T_sub, e_vars.k_sub)
     conv_out = convection(o.body, A_conv, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
@@ -41,14 +45,20 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     Q_evap = evap_out.Q_evap # evaporative heat loss
     
     # calculate balance
-    Q_in = Q_solar + Q_IR_in + Q_metab # energy in
-    Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
-    Q_in - Q_out # this must balance
+    Q_in = Q_solar + Q_ir_in + Q_metab # energy in
+    Q_out = Q_ir_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
+    #Q_in - Q_out # this must balance
+    Q_bal = Q_in - Q_out # this must balance
+
+    enbal = [Q_solar, Q_ir_in, Q_metab, Q_resp, Q_evap, Q_ir_out, Q_conv, Q_cond, Q_bal]
+    #enbal = [Q_solar = Q_solar, Q_ir_in = Q_ir_in, Q_metab = Q_metab, Q_resp = Q_resp, Q_evap = Q_evap, Q_ir_out = Q_ir_out, Q_conv = Q_conv, Q_cond = Q_cond, Q_bal = Q_bal]
+    masbal = [metab_out.V_O2, evap_out.m_resp, evap_out.m_cut, evap_out.m_eyes]
+    (Q_bal=Q_bal, T_core=T_core, T_surf=T_surf, T_lung=T_lung, enbal=enbal, masbal=masbal, resp_out=resp_out, solar_out=solar_out, ir_gain=ir_gain, ir_loss=ir_loss, conv_out=conv_out, evap_out=evap_out)
+
 end
 function heat_balance(insulation::Fur, params, organism, vars) # A method for organisms with fur
     #....
 end
-
 
 function heat_balance(T_x)
 
@@ -57,7 +67,8 @@ function heat_balance(T_x)
     A_sil = calc_silhouette_area(body_organism, Z)
 
     # calculate heat fluxes
-    Q_metab = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
+    metab_out = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
+    Q_metab = metab_out.Q_metab
     resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
     Q_resp = resp_out.Q_resp
     Q_gen_net = Q_metab - Q_resp
@@ -66,9 +77,12 @@ function heat_balance(T_x)
     T_surf = Tsurf_Tlung_out.T_surf
     #T_lung = Tsurf_Tlung_out.T_lung
     #Q_norm = Q_dir / cos(Z)
-    Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_tot, A_cond, F_sub, F_sky, α_sub, Q_sol, Q_dir, Q_dif)
-    Q_IR_in = radin(A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
-    Q_IR_out = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
+    solar_out = solar(α_org_dorsal, α_org_ventral, A_sil, A_tot, A_cond, F_sub, F_sky, α_sub, Q_sol, Q_dir, Q_dif)
+    Q_solar = solar_out.Q_solar
+    ir_gain = radin(A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
+    Q_ir_in = ir_gain.Q_ir_in
+    ir_loss = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
+    Q_ir_out = ir_loss.Q_ir_out
     Q_cond = conduction(A_cond, Le, T_surf, T_sub, k_sub)
     conv_out = convection(body_organism, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
     evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_conv, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
@@ -76,7 +90,13 @@ function heat_balance(T_x)
     Q_evap = evap_out.Q_evap
 
     # calculate balance
-    Q_in = Q_solar + Q_IR_in + Q_metab # energy in
-    Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
-    Q_in - Q_out # this must balance
+    Q_in = Q_solar + Q_ir_in + Q_metab # energy in
+    Q_out = Q_ir_out + Q_conv + Q_evap + Q_resp + Q_cond # energy out
+    #Q_in - Q_out # this must balance
+    Q_bal = Q_in - Q_out # this must balance
+
+    enbal = [Q_solar, Q_ir_in, Q_metab, Q_resp, Q_evap, Q_ir_out, Q_conv, Q_cond, Q_bal]
+    #enbal = [Q_solar = Q_solar, Q_ir_in = Q_ir_in, Q_metab = Q_metab, Q_resp = Q_resp, Q_evap = Q_evap, Q_ir_out = Q_ir_out, Q_conv = Q_conv, Q_cond = Q_cond, Q_bal = Q_bal]
+    masbal = [metab_out.V_O2, evap_out.m_resp, evap_out.m_cut, evap_out.m_eyes]
+    (Q_bal=Q_bal, T_core=T_core, T_surf=T_surf, T_lung=T_lung, enbal=enbal, masbal=masbal, resp_out=resp_out, solar_out=solar_out, ir_gain=ir_gain, ir_loss=ir_loss, conv_out=conv_out, evap_out=evap_out)
 end

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -7,7 +7,7 @@ heat_balance(mod::Model, e_params, vars) = heat_balance(stripparams(mod), stripp
 heat_balance(T_x, mod::Model, e_params, vars) = heat_balance(T_x, stripparams(mod), stripparams(e_params), vars)
 # A generic method that expands dispatch to include the insulation
 # this could be <:Ectotherm or <:Endotherm?
-heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, params(o), e_pars, vars)
+heat_balance(T_x, o::Organism, e_pars, vars) = heat_balance(T_x, insulation(o), o, traits(o), e_pars, vars)
 # A method for Naked organisms
 
 function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
@@ -16,14 +16,14 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     
     # compute areas for exchange
     A_tot = o.body.geometry.area
-    A_conv = A_tot * (1 - o_vars.p_cond)
-    A_cond = A_tot * o_vars.p_cond
+    A_conv = A_tot * (1 - pars.p_cond)
+    A_cond = A_tot * pars.p_cond
     A_sil = calc_silhouette_area(o.body, e_vars.zen)
 
     # calculate heat fluxes
     metab_out = metabolism(o.body.shape.mass, T_x, pars.M1, pars.M2, pars.M3)
     Q_metab = metab_out.Q_metab
-    resp_out = respiration(T_x, Q_metab, pars.fO2_extract, o_vars.pant, pars.rq, e_vars.T_air, e_vars.rh, e_pars.elev, e_pars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
+    resp_out = respiration(T_x, Q_metab, pars.fO2_extract, pars.pant, pars.rq, e_vars.T_air, e_vars.rh, e_pars.elev, e_vars.P_atmos, e_pars.fO2, e_pars.fCO2, e_pars.fN2)
     Q_resp = resp_out.Q_resp
     Q_gen_net = Q_metab - Q_resp
     Q_gen_spec = Q_gen_net / o.body.geometry.volume
@@ -39,8 +39,8 @@ function heat_balance(T_x, insulation::Naked, o, pars, e_pars, vars)
     Q_ir_out = ir_loss.Q_ir_out
     Le = 0.025m
     Q_cond = conduction(A_cond, Le, T_surf, e_vars.T_sub, e_vars.k_sub)
-    conv_out = convection(o.body, A_conv, e_vars.T_air, T_surf, e_vars.vel, e_pars.P_atmos, e_pars.elev, e_pars.fluid)
-    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, o_vars.p_wet, A_conv, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_pars.P_atmos)
+    conv_out = convection(o.body, A_conv, e_vars.T_air, T_surf, e_vars.vel, e_vars.P_atmos, e_pars.elev, e_pars.fluid)
+    evap_out = evaporation(T_x, T_surf, resp_out.m_resp, o_vars.ψ_org, pars.p_wet, A_conv, conv_out.Hd, pars.p_eyes, e_vars.T_air, e_vars.rh, e_vars.P_atmos)
     Q_conv = conv_out.Q_conv # convective heat loss
     Q_evap = evap_out.Q_evap # evaporative heat loss
     
@@ -64,16 +64,16 @@ function heat_balance(T_x)
 
     # compute areas for exchange
     A_conv = A_tot * (1 - p_cond)
-    A_sil = calc_silhouette_area(body_organism, Z)
+    A_sil = calc_silhouette_area(geometric_traits, Z)
 
     # calculate heat fluxes
-    metab_out = metabolism(body_organism.shape.mass, T_x, M1, M2, M3)
+    metab_out = metabolism(geometric_traits.shape.mass, T_x, M1, M2, M3)
     Q_metab = metab_out.Q_metab
     resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
     Q_resp = resp_out.Q_resp
     Q_gen_net = Q_metab - Q_resp
-    Q_gen_spec = Q_gen_net / body_organism.geometry.volume
-    Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_x)
+    Q_gen_spec = Q_gen_net / geometric_traits.geometry.volume
+    Tsurf_Tlung_out = get_Tsurf_Tlung(geometric_traits, k_body, Q_gen_spec, T_x)
     T_surf = Tsurf_Tlung_out.T_surf
     #T_lung = Tsurf_Tlung_out.T_lung
     #Q_norm = Q_dir / cos(Z)
@@ -84,7 +84,7 @@ function heat_balance(T_x)
     ir_loss = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
     Q_ir_out = ir_loss.Q_ir_out
     Q_cond = conduction(A_cond, Le, T_surf, T_sub, k_sub)
-    conv_out = convection(body_organism, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
+    conv_out = convection(geometric_traits, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
     evap_out = evaporation(T_x, T_surf, resp_out.m_resp, ψ_org, p_wet, A_conv, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
     Q_conv = conv_out.Q_conv
     Q_evap = evap_out.Q_evap

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -8,7 +8,7 @@ shape(b::AbstractBody) = b.shape # gets the shape from an object of type Abstrac
 insulation(o::AbstractOrganism) = body(o).insulation # gets the insulation from an object of type AbstractOrganism
 params(o::AbstractOrganism) = o.params # gets the parameters from an object of type AbstractOrganism
 
-Base.@kwdef struct OrganismParams{F}
+Base.@kwdef struct OrganismParams{F,K}
     α_org_dorsal::F = Param(0.8, bounds=(0.2, 1.0))
     α_org_ventral::F = Param(0.8, bounds=(0.2, 1.0))
     ϵ_org_dorsal::F = Param(0.95, bounds=(0.1, 0.0))
@@ -17,7 +17,7 @@ Base.@kwdef struct OrganismParams{F}
     F_sub::F = Param(0.4, bounds=(0.3, 0.5))
     p_eyes::F = Param(3e-4, bounds=(2e-4, 4e-4))
     fO2_extract::F = Param(0.20, bounds=(0.10, 0.30))
-    k_body::F = Param(0.5, bounds=(0.412, 2.8))
+    k_body::K = Param(0.5, bounds=(0.412, 2.8))#, units=u"W/m/K")
     rq::F = Param(0.8, bounds=(0.7, 0.9))
     M1::F = Param(0.013, bounds=(0.01, 0.02))
     M2::F = Param(0.8, bounds=(0.7, 0.9))

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -8,23 +8,23 @@ shape(b::AbstractBody) = b.shape # gets the shape from an object of type Abstrac
 insulation(o::AbstractOrganism) = body(o).insulation # gets the insulation from an object of type AbstractOrganism
 params(o::AbstractOrganism) = o.params # gets the parameters from an object of type AbstractOrganism
 
-Base.@kwdef struct OrganismParams{F,K}
-    α_org_dorsal::F = Param(0.8, bounds=(0.2, 1.0))
-    α_org_ventral::F = Param(0.8, bounds=(0.2, 1.0))
-    ϵ_org_dorsal::F = Param(0.95, bounds=(0.1, 0.0))
-    ϵ_org_ventral::F = Param(0.95, bounds=(0.1, 0.0))
+Base.@kwdef mutable struct OrganismParams{F,K,M}
+    α_org_dorsal::F = Param(0.85, bounds=(0.2, 1.0))
+    α_org_ventral::F = Param(0.85, bounds=(0.2, 1.0))
+    ϵ_org_dorsal::F = Param(0.95, bounds=(0.1, 1.0))
+    ϵ_org_ventral::F = Param(0.95, bounds=(0.1, 1.0))
     F_sky::F = Param(0.4, bounds=(0.3, 0.5))
     F_sub::F = Param(0.4, bounds=(0.3, 0.5))
-    p_eyes::F = Param(3e-4, bounds=(2e-4, 4e-4))
+    p_eyes::F = Param(0.0, bounds=(0.0, 4e-4))
     fO2_extract::F = Param(0.20, bounds=(0.10, 0.30))
-    k_body::K = Param(0.5, bounds=(0.412, 2.8))#, units=u"W/m/K")
+    k_body::K = Param(0.5, bounds=(0.412, 2.8), units=u"W/m/K")
     rq::F = Param(0.8, bounds=(0.7, 0.9))
-    M1::F = Param(0.013, bounds=(0.01, 0.02))
-    M2::F = Param(0.8, bounds=(0.7, 0.9))
-    M3::F = Param(0.038, bounds=(0.02, 0.04))
+    M1::M = Param(0.013, bounds=(0.01, 0.02))
+    M2::M = Param(0.8, bounds=(0.7, 0.9))
+    M3::M = Param(0.038, bounds=(0.02, 0.04))
 end
 
-Base.@kwdef struct OrganismalVars{T,P,F,B}
+Base.@kwdef mutable struct OrganismalVars{T,P,F,B}
     T_core::T = K(20°C)
     T_surf::T = K(20°C)
     ψ_org::P = -707J/kg

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -1,4 +1,3 @@
-
 # We have a generic abstract type for all organisms
 abstract type AbstractOrganism end
 
@@ -17,7 +16,7 @@ Base.@kwdef struct OrganismParams{F}
     F_sky::F = Param(0.4, bounds=(0.3, 0.5))
     F_sub::F = Param(0.4, bounds=(0.3, 0.5))
     p_eyes::F = Param(3e-4, bounds=(2e-4, 4e-4))
-    fO2_ext::F = Param(0.20, bounds=(0.10, 0.30))
+    fO2_extract::F = Param(0.20, bounds=(0.10, 0.30))
     rq::F = Param(0.8, bounds=(0.7, 0.9))
     M1::F = Param(0.013, bounds=(0.01, 0.02))
     M2::F = Param(0.8, bounds=(0.7, 0.9))

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -2,11 +2,11 @@
 abstract type AbstractOrganism end
 
 # With some generic methods to get the params and body
-body(o::AbstractOrganism) = o.body
-shape(o::AbstractOrganism) = body(o).shape
-shape(b::AbstractBody) = b.shape
-insulation(o::AbstractOrganism) = body(o).insulation
-params(o::AbstractOrganism) = o.params
+body(o::AbstractOrganism) = o.body # gets the body from an object of type AbstractOrganism
+shape(o::AbstractOrganism) = body(o).shape # gets the shape from an object of type AbstractOrganism
+shape(b::AbstractBody) = b.shape # gets the shape from an object of type AbstractBody
+insulation(o::AbstractOrganism) = body(o).insulation # gets the insulation from an object of type AbstractOrganism
+params(o::AbstractOrganism) = o.params # gets the parameters from an object of type AbstractOrganism
 
 Base.@kwdef struct OrganismParams{F}
     α_org_dorsal::F = Param(0.8, bounds=(0.2, 1.0))
@@ -17,6 +17,7 @@ Base.@kwdef struct OrganismParams{F}
     F_sub::F = Param(0.4, bounds=(0.3, 0.5))
     p_eyes::F = Param(3e-4, bounds=(2e-4, 4e-4))
     fO2_extract::F = Param(0.20, bounds=(0.10, 0.30))
+    k_body::F = Param(0.5, bounds=(0.412, 2.8))
     rq::F = Param(0.8, bounds=(0.7, 0.9))
     M1::F = Param(0.013, bounds=(0.01, 0.02))
     M2::F = Param(0.8, bounds=(0.7, 0.9))

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -6,9 +6,9 @@ body(o::AbstractOrganism) = o.body # gets the body from an object of type Abstra
 shape(o::AbstractOrganism) = body(o).shape # gets the shape from an object of type AbstractOrganism
 shape(b::AbstractBody) = b.shape # gets the shape from an object of type AbstractBody
 insulation(o::AbstractOrganism) = body(o).insulation # gets the insulation from an object of type AbstractOrganism
-params(o::AbstractOrganism) = o.params # gets the parameters from an object of type AbstractOrganism
+traits(o::AbstractOrganism) = o.traits # gets the traits from an object of type AbstractOrganism
 
-Base.@kwdef mutable struct OrganismParams{F,K,M}
+Base.@kwdef struct FunctionalTraits{F,K,M,B}
     α_org_dorsal::F = Param(0.85, bounds=(0.2, 1.0))
     α_org_ventral::F = Param(0.85, bounds=(0.2, 1.0))
     ϵ_org_dorsal::F = Param(0.95, bounds=(0.1, 1.0))
@@ -22,19 +22,20 @@ Base.@kwdef mutable struct OrganismParams{F,K,M}
     M1::M = Param(0.013, bounds=(0.01, 0.02))
     M2::M = Param(0.8, bounds=(0.7, 0.9))
     M3::M = Param(0.038, bounds=(0.02, 0.04))
+    p_wet::F = Param(0.001, bounds=(0.0, 1.0))
+    p_cond::F = Param(0.1, bounds=(0.0, 1.0))
+    pant::B = Param(1.0, bounds=(1.0, 10.0))
 end
 
-Base.@kwdef mutable struct OrganismalVars{T,P,F,B}
+Base.@kwdef mutable struct OrganismalVars{T,P}
     T_core::T = K(20°C)
     T_surf::T = K(20°C)
+    T_lung::T = K(20°C)
     ψ_org::P = -707J/kg
-    p_wet::F = 0.001
-    p_cond::F = 0.1
-    pant::B = 1
 end
 
 # Then define a concrete organism struct  
-struct Organism{B<:Body,P<:OrganismParams} <: AbstractOrganism
+struct Organism{B<:Body,T<:FunctionalTraits} <: AbstractOrganism
     body::B
-    params::P
+    traits::T
 end

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -103,18 +103,22 @@ T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C
 
 # using structs to pass parameters
 
+# define the geometry
 mass_organism = 0.04kg
 ρ_organism = 1000kg/m^3
 shapeb_organism = 2
 shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism)
 body_organism = Body(shape_organism, Naked())
 
+# construct the Model which holds the parameters of the organism in the Organism concrete struct, of type AbstractOrganism
 lizard = Model(Organism(body_organism, OrganismParams()))
+# get the environmental parameters
 environmental_params = EnvironmentalParams()
+# get the variables for both the organism and environment
 variables = (organism=OrganismalVars(), environment=EnvironmentalVars())
 
-heat_balance(lizard, environmental_params, variables)
-
-T_air = EnvironmentalVars().Ta
+# define the method 'heat_balance' for passing to find_zero, which dispatches off 'lizard' 
+T_air = EnvironmentalVars().T_air
+heat_balance(T_air, lizard, environmental_params, variables)
 T_surf_s = find_zero(t -> heat_balance(t, lizard, environmental_params, variables), (T_air - 40K, T_air + 100K), Bisection())
 T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -14,37 +14,38 @@ include("../src/heat_balance.jl")
 T_air = K(20°C)
 T_sky = K(-5°C)
 T_sub = K(30°C)
-k_sub = 0.15W/m/K
+k_sub = 0.5W/m/K
 P_atmos = 101325Pa
 rh = 5
 elev = 0m
 vel = 1m/s
 fluid = 0
 Z = 20°
-Q_dir = 1000W/m^2
-Q_dif = 200W/m^2
-Q_norm = Q_dir / cos(Z) # use this as Q_dir if want organism to be orienting towards beam
+Q_sol = 1000W/m^2
+Q_dif = Q_sol * 0.1
+Q_norm = Q_sol / cos(Z) # use this as Q_dir if want organism to be orienting towards beam
+Q_dir = Q_norm - Q_dif
 α_sub = 0.2
 ϵ_sub = 1
 ϵ_sky = 1
 fO2 = 0.2095
-fCO2 = 0.00042
+fCO2 = 0.0003
 fN2 = 0.79
 
 # organism morphology
 mass_organism = 0.04kg
 ρ_organism = 1000kg/m^3
-shapeb_organism = 2
+shapeb_organism = 3
 shapec_organism = 2 / 3
 #shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
 shape_organism = Ellipsoid(mass_organism, ρ_organism, shapeb_organism, shapec_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
 body_organism = Body(shape_organism, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
-p_eyes = 0.03 / 100
+p_eyes = 0 / 100
 p_cond = 0.1
 p_cont = 0
 A_tot = body_organism.geometry.area
-A_v = A_tot * p_cond
-A_c = A_tot * (1 - p_cond)
+A_cond = A_tot * p_cond
+A_conv = A_tot * (1 - p_cond)
 A_sil = calc_silhouette_area(body_organism, Z)
 A_up = A_tot / 2
 A_down = A_tot / 2
@@ -68,26 +69,24 @@ M2 = 0.8
 M3 = 0.038
 
 # organism state
-T_core = K(29°C)
+T_core = K(35.35236°C)
 
 # calculate heat fluxes
 Q_metab = metabolism(mass_organism, T_core, M1, M2, M3)
-T_x = T_air
-resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
+resp_out = respiration(T_core, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
 Q_resp = resp_out.Q_resp
 Q_gen_net = Q_metab - Q_resp
 Q_gen_spec = Q_gen_net / body_organism.geometry.volume
 Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_core)
 T_surf = Tsurf_Tlung_out.T_surf
 T_lung = Tsurf_Tlung_out.T_lung
-Q_norm = Q_dir / cos(Z)
-Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
-Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
-Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
+Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_tot, A_cond, F_sub, F_sky, α_sub, Q_sol, Q_dir, Q_dif)
+Q_IR_in = radin(A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
+Q_IR_out = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
 Q_metab = metabolism(body_organism.shape.mass, T_core, M1, M2, M3)
-Q_cond = conduction(A_v, Le, T_surf, T_sub, k_sub)
-conv_out = convection(body_organism, A_c, T_air, T_surf, vel, P_atmos, elev, fluid)
-evap_out = evaporation(T_core, T_surf, resp_out.m_resp, ψ_org, p_wet, A_c, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
+Q_cond = conduction(A_cond, Le, T_surf, T_sub, k_sub)
+conv_out = convection(body_organism, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
+evap_out = evaporation(T_core, T_surf, resp_out.m_resp, ψ_org, p_wet, A_conv, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
 Q_conv = conv_out.Q_conv
 Q_evap = evap_out.Q_evap
 Q_resp = resp_out.Q_resp
@@ -106,9 +105,13 @@ T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C
 # define the geometry
 mass_organism = 0.04kg
 ρ_organism = 1000kg/m^3
-shapeb_organism = 2
-shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism)
-body_organism = Body(shape_organism, Naked())
+#shapeb_organism = 2
+shapeb_organism = 3
+shapec_organism = 2 / 3
+#shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism)
+#body_organism = Body(shape_organism, Naked())
+shape_organism = Ellipsoid(mass_organism, ρ_organism, shapeb_organism, shapec_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+body_organism = Body(shape_organism, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
 
 # construct the Model which holds the parameters of the organism in the Organism concrete struct, of type AbstractOrganism
 lizard = Model(Organism(body_organism, OrganismParams()))

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -69,7 +69,7 @@ M2 = 0.8
 M3 = 0.038
 
 # organism state
-T_core = K(35.35236°C)
+T_core = K(35.497186492935384°C)
 
 # calculate heat fluxes
 metab_out = metabolism(mass_organism, T_core, M1, M2, M3)

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -1,7 +1,7 @@
 using Revise
 using ModelParameters
 using Unitful
-using Unitful: °, rad, °C, K, Pa, kPa, MPa, J, kJ, W, L, g, kg, cm, m, s, hr, d, mol, mmol, μmol, σ, R
+using Unitful: °, rad, °C, K, Pa, J, kJ, W, L, g, kg, cm, m, s, hr, d, mol, R
 using Roots
 
 include("../src/geometry.jl")
@@ -11,10 +11,10 @@ include("../src/biophysics.jl")
 include("../src/heat_balance.jl")
 
 # environment
-T_air = (20+273.15)K
-T_sky = (-5+273.15)K
-T_sub = (30+273.15)K
-k_sub = 0.5W/m/K
+T_air = K(20°C)
+T_sky = K(-5°C)
+T_sub = K(30°C)
+k_sub = 0.15W/m/K
 P_atmos = 101325Pa
 rh = 5
 elev = 0m
@@ -31,56 +31,63 @@ fO2 = 0.2095
 fCO2 = 0.00042
 fN2 = 0.79
 
-# organism geometry
+# organism morphology
 mass_organism = 0.04kg
 ρ_organism = 1000kg/m^3
 shapeb_organism = 2
-shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+shapec_organism = 2 / 3
+#shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+shape_organism = Ellipsoid(mass_organism, ρ_organism, shapeb_organism, shapec_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
 body_organism = Body(shape_organism, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
-
+p_eyes = 0.03 / 100
+p_cond = 0.1
+p_cont = 0
 A_tot = body_organism.geometry.area
-
-T_core = K(20°C)
-T_surf = K(20°C) # skin
+A_v = A_tot * p_cond
+A_c = A_tot * (1 - p_cond)
+A_sil = calc_silhouette_area(body_organism, Z)
+A_up = A_tot / 2
+A_down = A_tot / 2
 F_sky = 0.4
 F_sub = 0.4
 α_org_dorsal = 0.85
 α_org_ventral = 0.85
 ϵ_org_dorsal = 0.95
 ϵ_org_ventral = 0.95
+Le = 0.025m
+
+# organism physiology
+k_body = 0.5W/m/K
 ψ_org = -7.07 * 100J/kg
 p_wet = 0.1/100
-p_eyes = 0.03 / 100
-p_cond = 0.1
-p_cont = 0
-fO2_ext = 0.20
-pant = 1
+fO2_extract = 0.20
+pant = 1.0
 rq = 0.8
 M1 = 0.013
 M2 = 0.8
 M3 = 0.038
 
-A_v = A_tot * p_cond
-A_c = A_tot * (1 - p_cond)
-A_sil = calc_silhouette_area(body_organism, Z)
-A_up = A_tot / 2
-A_down = A_tot / 2
+# organism state
+T_core = K(29°C)
 
+# calculate heat fluxes
+Q_metab = metabolism(mass_organism, T_core, M1, M2, M3)
+T_x = T_air
+resp_out = respiration(T_x, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
+Q_resp = resp_out.Q_resp
+Q_gen_net = Q_metab - Q_resp
+Q_gen_spec = Q_gen_net / body_organism.geometry.volume
+Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_core)
+T_surf = Tsurf_Tlung_out.T_surf
+T_lung = Tsurf_Tlung_out.T_lung
 Q_norm = Q_dir / cos(Z)
 Q_solar = solar(α_org_dorsal, α_org_ventral, A_sil, A_up, A_down, F_sub, F_sky, α_sub, Q_dir, Q_dif)
 Q_IR_in = radin(A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral, ϵ_sub, ϵ_sky, T_sky, T_sub)
 Q_IR_out = radout(T_surf, A_tot, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
 Q_metab = metabolism(body_organism.shape.mass, T_core, M1, M2, M3)
-Le = 0.025m
 Q_cond = conduction(A_v, Le, T_surf, T_sub, k_sub)
-
-T_x = T_air
-
 conv_out = convection(body_organism, A_c, T_air, T_surf, vel, P_atmos, elev, fluid)
-resp_out = respiration(T_x, Q_metab, fO2_ext, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
-m_resp = resp_out.m_resp
-evap_out = evaporation(T_core, T_surf, m_resp, ψ_org, p_wet, A_tot, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
-
+evap_out = evaporation(T_core, T_surf, resp_out.m_resp, ψ_org, p_wet, A_c, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
 Q_conv = conv_out.Q_conv
 Q_evap = evap_out.Q_evap
 Q_resp = resp_out.Q_resp
@@ -89,7 +96,6 @@ Q_in = Q_solar + Q_IR_in + Q_metab
 Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond
 Q_in - Q_out
 
-T_x = T_air
 
 T_surf_s = find_zero(heat_balance, (T_air - 40K, T_air + 100K), Bisection())
 T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -96,8 +96,8 @@ Q_out = Q_IR_out + Q_conv + Q_evap + Q_resp + Q_cond
 Q_in - Q_out
 
 
-T_surf_s = find_zero(heat_balance, (T_air - 40K, T_air + 100K), Bisection())
-T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C
+T_core_s = find_zero(heat_balance, (T_air - 40K, T_air + 100K), Bisection())
+T_core_C = (Unitful.ustrip(T_core_s) - 273.15)°C
 
 
 # using structs to pass parameters
@@ -123,5 +123,5 @@ variables = (organism=OrganismalVars(), environment=EnvironmentalVars())
 # define the method 'heat_balance' for passing to find_zero, which dispatches off 'lizard' 
 T_air = EnvironmentalVars().T_air
 heat_balance(T_air, lizard, environmental_params, variables)
-T_surf_s = find_zero(t -> heat_balance(t, lizard, environmental_params, variables), (T_air - 40K, T_air + 100K), Bisection())
-T_surf_C = (Unitful.ustrip(T_surf_s) - 273.15)°C
+T_core_s = find_zero(t -> heat_balance(t, lizard, environmental_params, variables), (T_air - 40K, T_air + 100K), Bisection())
+T_core_C = (Unitful.ustrip(T_core_s) - 273.15)°C

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -23,7 +23,7 @@ fluid = 0
 Z = 20°
 Q_sol = 1000W/m^2
 Q_dif = Q_sol * 0.1
-Q_norm = Q_sol / cos(Z) # use this as Q_dir if want organism to be orienting towards beam
+Q_norm = Q_sol / cos(Z) # use this in calculating Q_dir if want organism to be orienting towards beam
 Q_dir = Q_norm - Q_dif
 α_sub = 0.2
 ϵ_sub = 1
@@ -33,20 +33,20 @@ fCO2 = 0.0003
 fN2 = 0.79
 
 # organism morphology
-mass_organism = 0.04kg
-ρ_organism = 1000kg/m^3
-shapeb_organism = 3
-shapec_organism = 2 / 3
-#shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
-shape_organism = Ellipsoid(mass_organism, ρ_organism, shapeb_organism, shapec_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
-body_organism = Body(shape_organism, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
+mass = 0.04kg
+ρ_body = 1000kg/m^3
+shapeb = 3
+shapec = 2 / 3
+#shape_body = Cylinder(mass, ρ_body, shapeb) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+shape_body = Ellipsoid(mass, ρ_body, shapeb, shapec) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+geometric_traits = Body(shape_body, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
 p_eyes = 0 / 100
 p_cond = 0.1
 p_cont = 0
-A_tot = body_organism.geometry.area
+A_tot = geometric_traits.geometry.area
 A_cond = A_tot * p_cond
 A_conv = A_tot * (1 - p_cond)
-A_sil = calc_silhouette_area(body_organism, Z)
+A_sil = calc_silhouette_area(geometric_traits, Z)
 A_up = A_tot / 2
 A_down = A_tot / 2
 F_sky = 0.4
@@ -72,13 +72,13 @@ M3 = 0.038
 T_core = K(35.497186492935384°C)
 
 # calculate heat fluxes
-metab_out = metabolism(mass_organism, T_core, M1, M2, M3)
+metab_out = metabolism(mass, T_core, M1, M2, M3)
 Q_metab = metab_out.Q_metab
 resp_out = respiration(T_core, Q_metab, fO2_extract, pant, rq, T_air, rh, elev, P_atmos, fO2, fCO2, fN2)
 Q_resp = resp_out.Q_resp
 Q_gen_net = Q_metab - Q_resp
-Q_gen_spec = Q_gen_net / body_organism.geometry.volume
-Tsurf_Tlung_out = get_Tsurf_Tlung(body_organism, k_body, Q_gen_spec, T_core)
+Q_gen_spec = Q_gen_net / geometric_traits.geometry.volume
+Tsurf_Tlung_out = get_Tsurf_Tlung(geometric_traits, k_body, Q_gen_spec, T_core)
 T_surf = Tsurf_Tlung_out.T_surf
 T_lung = Tsurf_Tlung_out.T_lung
 solar_out = solar(α_org_dorsal, α_org_ventral, A_sil, A_tot, A_cond, F_sub, F_sky, α_sub, Q_sol, Q_dir, Q_dif)
@@ -88,7 +88,7 @@ Q_ir_in = ir_gain.Q_ir_in
 ir_loss = radout(T_surf, A_tot, A_cond, F_sky, F_sub, ϵ_org_dorsal, ϵ_org_ventral)
 Q_ir_out = ir_loss.Q_ir_out
 Q_cond = conduction(A_cond, Le, T_surf, T_sub, k_sub)
-conv_out = convection(body_organism, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
+conv_out = convection(geometric_traits, A_conv, T_air, T_surf, vel, P_atmos, elev, fluid)
 evap_out = evaporation(T_core, T_surf, resp_out.m_resp, ψ_org, p_wet, A_conv, conv_out.Hd, p_eyes, T_air, rh, P_atmos)
 Q_conv = conv_out.Q_conv
 Q_evap = evap_out.Q_evap
@@ -107,18 +107,18 @@ heat_balance_out = heat_balance(T_core_s)
 # using structs to pass parameters
 
 # define the geometry
-mass_organism = 0.04kg
-ρ_organism = 1000kg/m^3
-#shapeb_organism = 2
-shapeb_organism = 3
-shapec_organism = 2 / 3
-#shape_organism = Cylinder(mass_organism, ρ_organism, shapeb_organism)
-#body_organism = Body(shape_organism, Naked())
-shape_organism = Ellipsoid(mass_organism, ρ_organism, shapeb_organism, shapec_organism) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
-body_organism = Body(shape_organism, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
+mass = 0.04kg
+ρ_body = 1000kg/m^3
+#shapeb = 2
+shapeb = 3
+shapec = 2 / 3
+#shape_body = Cylinder(mass, ρ_body, shapeb)
+#geometric_traits = Body(shape_body, Naked())
+shape_body = Ellipsoid(mass, ρ_body, shapeb, shapec) # define trunkshape as a Cylinder struct of type 'Shape' and give it required values
+geometric_traits = Body(shape_body, Naked()) # construct a Body, which is naked - this constructor will apply the 'geometry' function to the inputs and return a struct that has the struct for the 'Shape' type, as well as the insulation and the geometry struct
 
 # construct the Model which holds the parameters of the organism in the Organism concrete struct, of type AbstractOrganism
-lizard = Model(Organism(body_organism, OrganismParams()))
+lizard = Model(Organism(geometric_traits, FunctionalTraits()))
 # get the environmental parameters
 environmental_params = EnvironmentalParams()
 # get the variables for both the organism and environment


### PR DESCRIPTION
Making some cosmetic changes and adding in functions for T_skin and T_lung, incorporating T_skin and also Q_resp into heat budget calculation. Haven't yet incorporated this into the struct approach to passing parameters.

I've deleted the heat_balance functions that didn't pass a guessed T_b value in - OK?

Also I did a careful check against ectoR_devel and found a few issues, e.g. latent heat wasn't being calculated properly because of a parenthesis typo, also the conducting surface wasn't being subtracted from ventral radiation exchange, and we need to past horizontal plane solar plus diffuse and direct beam solar to the solar radiation routine. The formula for the silhouette area of an ellipse wasn't the same as in the ectotherm model so I've made them identical for now - we'll want the zenith-angle specific one eventually. Now the comparison with ectoR_devel is very close, e.g. predicted Tb with Julia version in the biophysics test is 35.5 and with the ectoR_devel for the same conditions it is 35.35. Not sure what is the cause of the slight different yet and if it's a problem.